### PR TITLE
Chore: remove unused state for max BW

### DIFF
--- a/src/data/store/selectors/operationPerf.selectors.ts
+++ b/src/data/store/selectors/operationPerf.selectors.ts
@@ -10,6 +10,4 @@ export const getOperationPerformanceTreshold = (state: RootState) =>
 export const getShowOperationPerformanceGrid = (state: RootState) =>
     state.operationPerformance.showOperationPerformanceGrid;
 
-export const getMaxBwLimitedFactor = (state: RootState) => state.operationPerformance.maxBwLimitedFactor;
-
 export const getOperationRatioThreshold = (state: RootState) => state.operationPerformance.operationRatioThreshold;

--- a/src/data/store/slices/operationPerf.slice.ts
+++ b/src/data/store/slices/operationPerf.slice.ts
@@ -3,23 +3,17 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 import { createSlice } from '@reduxjs/toolkit';
-import {
-    INITIAL_OPERATION_PERFORMANCE_THRESHOLD,
-    MAX_MODEL_RATIO_THRESHOLD,
-    MAX_OPERATION_PERFORMANCE_THRESHOLD,
-} from '../../constants';
+import { INITIAL_OPERATION_PERFORMANCE_THRESHOLD, MAX_MODEL_RATIO_THRESHOLD } from '../../constants';
 
 interface OperationPerformanceState {
     operationPerformanceTreshold: number;
     showOperationPerformanceGrid: boolean;
-    maxBwLimitedFactor: number;
     operationRatioThreshold: number;
 }
 
 const operationPerformanceInitialState: OperationPerformanceState = {
     operationPerformanceTreshold: INITIAL_OPERATION_PERFORMANCE_THRESHOLD,
     showOperationPerformanceGrid: false,
-    maxBwLimitedFactor: MAX_OPERATION_PERFORMANCE_THRESHOLD,
     operationRatioThreshold: MAX_MODEL_RATIO_THRESHOLD,
 };
 
@@ -33,20 +27,13 @@ const operationPerformanceSlice = createSlice({
         updateShowOperationPerformanceGrid: (state, action) => {
             state.showOperationPerformanceGrid = action.payload;
         },
-        updateMaxBwLimitedFactor: (state, action) => {
-            state.maxBwLimitedFactor = action.payload;
-        },
         updateOperationRatioThreshold: (state, action) => {
             state.operationRatioThreshold = action.payload;
         },
     },
 });
 
-export const {
-    updateOperationPerformanceThreshold,
-    updateShowOperationPerformanceGrid,
-    updateMaxBwLimitedFactor,
-    updateOperationRatioThreshold,
-} = operationPerformanceSlice.actions;
+export const { updateOperationPerformanceThreshold, updateShowOperationPerformanceGrid, updateOperationRatioThreshold } =
+    operationPerformanceSlice.actions;
 
 export const operationPerformanceReducer = operationPerformanceSlice.reducer;

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -15,7 +15,7 @@ import { getAvailableGraphNames, loadCluster, loadGraph, validatePerfResultsFold
 
 import { dialog } from '@electron/remote';
 import { ApplicationMode } from 'data/Types';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { sortPerfAnalyzerGraphnames } from 'utils/FilenameSorters';
 import { ClusterContext, ClusterModel } from '../../data/ClusterContext';
@@ -29,7 +29,6 @@ import {
     resetNetworksState,
 } from '../../data/store/slices/linkSaturation.slice';
 import { initialLoadAllNodesData } from '../../data/store/slices/nodeSelection.slice';
-import { updateMaxBwLimitedFactor } from '../../data/store/slices/operationPerf.slice';
 import { loadPipeSelection, resetPipeSelection } from '../../data/store/slices/pipeSelection.slice';
 import { mapIterable } from '../../utils/IterableHelpers';
 import useLogging from './useLogging.hook';
@@ -40,22 +39,11 @@ const usePerfAnalyzerFileLoader = () => {
     const [error, setError] = useState<string | null>(null);
     const logging = useLogging();
     const { setCluster } = useContext<ClusterModel>(ClusterContext);
-    const { getActiveGraphOnChip, setActiveGraph, loadGraphOnChips, resetGraphOnChipState } =
-        useContext(GraphOnChipContext);
+    const { setActiveGraph, loadGraphOnChips, resetGraphOnChipState } = useContext(GraphOnChipContext);
 
-    const activeGraphOnChip = getActiveGraphOnChip();
     const navigate = useNavigate();
 
     const logger = useLogging();
-
-
-    useEffect(() => {
-        if (activeGraphOnChip) {
-            // TODO: this needs to go into bulk loading and useEffect shoudl be removed
-            dispatch(updateMaxBwLimitedFactor(activeGraphOnChip.details.maxBwLimitedFactor));
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeGraphOnChip]);
 
     const openPerfAnalyzerFolderDialog = async () => {
         const folderList = dialog.showOpenDialogSync({


### PR DESCRIPTION
The value for `maxBwLimitedFactor` is already present in context. We had only a leftover setting of it on redux with no read of the value.

This change removes this variable from redux.