### PR TITLE
Chore: add strict index checks to typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
+    "noUncheckedIndexedAccess": true,
     "allowJs": true,
     "outDir": ".erb/dll",
      "skipLibCheck": true


### PR DESCRIPTION
Add [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) option to typescript so it will complain about possible `undefined` results when accessing items on arrays or on objects.