### PR TITLE
Fix: improve grid rendering performance on temporal epochs

### DIFF
--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -1080,6 +1080,10 @@ export class ComputeNode {
             if (link.type === LinkType.PCIE) {
                 node.internalLinks.set(linkName, link as PCIeLink);
             }
+
+            if (link.name === EthernetLinkName.ETH_IN || link.name === EthernetLinkName.ETH_OUT) {
+                node.externalPipes.push(...link.pipes);
+            }
         });
 
         // Associate with operation
@@ -1132,6 +1136,8 @@ export class ComputeNode {
     public producerPipes: Pipe[] = [];
 
     public pipes: Pipe[] = [];
+
+    public externalPipes: PipeSegment[] = [];
 
     /**
      * only relevant for dram nodes

--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -1027,7 +1027,7 @@ export interface ComputeNodeSiblings {
 }
 
 export interface NodeInitialState {
-    id: string;
+    uid: string;
     queueNameList: string[];
     opName: string;
     dramChannelId: number;
@@ -1180,7 +1180,7 @@ export class ComputeNode {
 
     public generateInitialState(): NodeInitialState {
         return {
-            id: this.uid,
+            uid: this.uid,
             queueNameList: this.queueList.map((queue) => queue.name),
             opName: this.opName,
             dramChannelId: this.dramChannelId,

--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -1032,6 +1032,7 @@ export interface NodeInitialState {
     opName: string;
     dramChannelId: number;
     graphName: string;
+    chipId: number;
 }
 
 export class ComputeNode {
@@ -1185,6 +1186,7 @@ export class ComputeNode {
             opName: this.opName,
             dramChannelId: this.dramChannelId,
             graphName,
+            chipId: this.chipId,
         };
     }
 

--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -1031,7 +1031,6 @@ export interface NodeInitialState {
     queueNameList: string[];
     opName: string;
     dramChannelId: number;
-    graphName: string;
     chipId: number;
 }
 
@@ -1179,13 +1178,12 @@ export class ComputeNode {
         return this.operation?.name || '';
     }
 
-    public generateInitialState(graphName: string): NodeInitialState {
+    public generateInitialState(): NodeInitialState {
         return {
             id: this.uid,
             queueNameList: this.queueList.map((queue) => queue.name),
             opName: this.opName,
             dramChannelId: this.dramChannelId,
-            graphName,
             chipId: this.chipId,
         };
     }

--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -1026,6 +1026,14 @@ export interface ComputeNodeSiblings {
     bottom?: Loc;
 }
 
+export interface NodeInitialState {
+    id: string;
+    queueNameList: string[];
+    opName: string;
+    dramChannelId: number;
+    graphName: string;
+}
+
 export class ComputeNode {
     /** Creates a ComputeNode from a Node JSON object in a Netlist Analyzer output file.
      *
@@ -1170,7 +1178,7 @@ export class ComputeNode {
         return this.operation?.name || '';
     }
 
-    public generateInitialState(graphName: string) {
+    public generateInitialState(graphName: string): NodeInitialState {
         return {
             id: this.uid,
             queueNameList: this.queueList.map((queue) => queue.name),

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -37,7 +37,6 @@ interface GraphOnChipContextType {
     getActiveGraphOnChip: () => GraphOnChip | undefined;
     getPreviousGraphName: () => string | undefined;
     getNextGraphName: () => string | undefined;
-    setActiveGraph: (graphName: string) => void;
     selectPreviousGraph: () => void;
     selectNextGraph: () => void;
     getGraphOnChip: (graphName: string) => GraphOnChip | undefined;
@@ -65,7 +64,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getActiveGraphOnChip: () => undefined,
     getPreviousGraphName: () => undefined,
     getNextGraphName: () => undefined,
-    setActiveGraph: () => {},
     selectPreviousGraph: () => {},
     selectNextGraph: () => {},
     getGraphOnChip: () => undefined,
@@ -190,25 +188,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         return state.visitedGraphsHistory[state.currentGraphIndex + 1];
     }, [state.currentGraphIndex, state.visitedGraphsHistory]);
 
-    const setActiveGraph = useCallback((graphName: string) => {
-        setState((prevState) => {
-            if (prevState.visitedGraphsHistory[prevState.currentGraphIndex] === graphName) {
-                return prevState;
-            }
-
-            const newGraphList = [
-                ...prevState.visitedGraphsHistory.slice(0, Math.max(0, prevState.currentGraphIndex + 1)),
-                graphName,
-            ];
-
-            return {
-                ...prevState,
-                currentGraphIndex: newGraphList.length - 1,
-                visitedGraphsHistory: newGraphList,
-            };
-        });
-    }, []);
-
     const selectPreviousGraph = useCallback(() => {
         setState((prevState) => ({
             ...prevState,
@@ -244,7 +223,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             resetGraphOnChipState: reset,
             getPreviousGraphName,
             getNextGraphName,
-            setActiveGraph,
             selectPreviousGraph,
             selectNextGraph,
             graphOnChipList: state.graphOnChipList,
@@ -263,7 +241,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             reset,
             getPreviousGraphName,
             getNextGraphName,
-            setActiveGraph,
             selectPreviousGraph,
             selectNextGraph,
             state.graphOnChipList,

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -33,13 +33,13 @@ interface GraphOnChipContextType {
     getGraphRelationshipList: () => GraphRelationship[];
     getGraphRelationshipByGraphName: (graphName: string) => GraphRelationship | undefined;
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
+    /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
     getActiveGraphOnChip: () => GraphOnChip | undefined;
     getPreviousGraphName: () => string | undefined;
     getNextGraphName: () => string | undefined;
     selectPreviousGraph: () => void;
     selectNextGraph: () => void;
     getGraphOnChip: (temporalEpoch: number, chipId: number) => GraphOnChip | undefined;
-    graphOnChipList: Record<string, GraphOnChip>;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
 }
@@ -64,7 +64,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     selectPreviousGraph: () => {},
     selectNextGraph: () => {},
     getGraphOnChip: () => undefined,
-    graphOnChipList: {},
     getOperand: () => undefined,
     getGraphOnChipListForTemporalEpoch: () => [],
 });
@@ -146,7 +145,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         );
     }, [state.graphs]);
 
-    /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
     const getActiveGraphOnChip = useCallback(() => undefined, []);
 
     const getGraphOnChipListForTemporalEpoch = useCallback(
@@ -209,7 +207,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getNextGraphName,
             selectPreviousGraph,
             selectNextGraph,
-            graphOnChipList: state.graphOnChipList,
             getOperand,
             getGraphOnChipListForTemporalEpoch,
         }),
@@ -225,7 +222,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getNextGraphName,
             selectPreviousGraph,
             selectNextGraph,
-            state.graphOnChipList,
             getOperand,
             getGraphOnChipListForTemporalEpoch,
         ],

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -38,7 +38,7 @@ interface GraphOnChipContextType {
     getNextGraphName: () => string | undefined;
     selectPreviousGraph: () => void;
     selectNextGraph: () => void;
-    getGraphOnChip: (chipId: number) => GraphOnChip | undefined;
+    getGraphOnChip: (temporalEpoch: number, chipId: number) => GraphOnChip | undefined;
     graphOnChipList: Record<string, GraphOnChip>;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
@@ -108,10 +108,14 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }, []);
 
     const getGraphOnChip = useCallback(
-        (chipId: number) => {
-            return Object.values(state.graphOnChipList).find((graph) => graph.chipId === chipId);
+        (temporalEpoch: number, chipId: number) => {
+            const graphRelationship = [...state.graphs.values()].find(
+                (graph) => graph.temporalEpoch === temporalEpoch && graph.chipId === chipId,
+            );
+
+            return state.graphOnChipList[graphRelationship?.name ?? ''];
         },
-        [state.graphOnChipList],
+        [state.graphs, state.graphOnChipList],
     );
 
     const reset = useCallback(() => {
@@ -142,9 +146,8 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         );
     }, [state.graphs]);
 
-    const getActiveGraphOnChip = useCallback(() => {
-        return state.graphOnChipList[state.visitedGraphsHistory[state.currentGraphIndex] ?? ''];
-    }, [state]);
+    /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
+    const getActiveGraphOnChip = useCallback(() => undefined, []);
 
     const getGraphOnChipListForTemporalEpoch = useCallback(
         (epoch: number) => {

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -14,6 +14,7 @@ interface OperandDescriptor {
     temporalEpoch: number;
     type: GraphVertexType;
     operand: Operand;
+    chipId: number;
 }
 
 interface ApplicationModelState {
@@ -90,6 +91,7 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                             temporalEpoch,
                             type: GraphVertexType.OPERATION,
                             operand: operation as Operand,
+                            chipId: graphOnChip.chipId,
                         })),
                     ...[...graphOnChip.queues].map((queue) => ({
                         name: queue.name,
@@ -97,6 +99,7 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                         temporalEpoch,
                         type: GraphVertexType.QUEUE,
                         operand: queue as Operand,
+                        chipId: graphOnChip.chipId,
                     })),
                 ];
             })

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -31,8 +31,6 @@ interface GraphOnChipContextType {
     getGraphRelationshipList: () => GraphRelationship[];
     getGraphRelationshipByGraphName: (graphName: string) => GraphRelationship | undefined;
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
-    /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
-    getActiveGraphOnChip: () => GraphOnChip | undefined;
     getGraphOnChip: (
         temporalEpoch: number,
         chipId?: number,
@@ -53,7 +51,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getGraphRelationshipList: () => [],
     getGraphRelationshipByGraphName: () => undefined,
     getGraphsListByTemporalEpoch: () => new Map(),
-    getActiveGraphOnChip: () => undefined,
     getGraphOnChip: () => [],
     getOperand: () => undefined,
     getGraphOnChipListForTemporalEpoch: () => [],
@@ -154,8 +151,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         );
     }, [state.graphs]);
 
-    const getActiveGraphOnChip = useCallback(() => undefined, []);
-
     const getGraphOnChipListForTemporalEpoch = useCallback(
         (epoch: number) => {
             const graphArray: { graph: GraphRelationship; graphOnChip: GraphOnChip }[] = [];
@@ -182,7 +177,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const value = useMemo<GraphOnChipContextType>(
         () => ({
             loadGraphOnChips,
-            getActiveGraphOnChip,
             getGraphRelationshipList,
             getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
@@ -193,7 +187,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }),
         [
             loadGraphOnChips,
-            getActiveGraphOnChip,
             getGraphRelationshipList,
             getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -19,8 +19,6 @@ interface OperandDescriptor {
 
 interface ApplicationModelState {
     operands: Map<string, OperandDescriptor>;
-    visitedGraphsHistory: string[];
-    currentGraphIndex: number;
     graphOnChipList: {
         [graphName: string]: GraphOnChip;
     };
@@ -35,10 +33,6 @@ interface GraphOnChipContextType {
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
     /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
     getActiveGraphOnChip: () => GraphOnChip | undefined;
-    getPreviousGraphName: () => string | undefined;
-    getNextGraphName: () => string | undefined;
-    selectPreviousGraph: () => void;
-    selectNextGraph: () => void;
     getGraphOnChip: (temporalEpoch: number, chipId: number) => GraphOnChip | undefined;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
@@ -46,8 +40,6 @@ interface GraphOnChipContextType {
 
 const applicationModelState: ApplicationModelState = {
     operands: new Map<string, OperandDescriptor>(),
-    visitedGraphsHistory: [],
-    currentGraphIndex: 0,
     graphOnChipList: {},
     graphs: new Map<string, GraphRelationship>(),
 };
@@ -59,10 +51,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getGraphRelationshipByGraphName: () => undefined,
     getGraphsListByTemporalEpoch: () => new Map(),
     getActiveGraphOnChip: () => undefined,
-    getPreviousGraphName: () => undefined,
-    getNextGraphName: () => undefined,
-    selectPreviousGraph: () => {},
-    selectNextGraph: () => {},
     getGraphOnChip: () => undefined,
     getOperand: () => undefined,
     getGraphOnChipListForTemporalEpoch: () => [],
@@ -98,8 +86,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             })
             .flat();
         setState({
-            visitedGraphsHistory: [],
-            currentGraphIndex: 0,
             graphOnChipList: Object.fromEntries(newChips.map((chip, index) => [graphs[index].name, chip])),
             graphs: new Map(graphs.map((graph) => [graph.name, graph])),
             operands: new Map(operands.map((edge) => [edge.name, edge])),
@@ -163,30 +149,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         [state.graphOnChipList, state.graphs],
     );
 
-    const getPreviousGraphName = useCallback(() => {
-        return state.visitedGraphsHistory[state.currentGraphIndex - 1];
-    }, [state.currentGraphIndex, state.visitedGraphsHistory]);
-
-    const getNextGraphName = useCallback(() => {
-        return state.visitedGraphsHistory[state.currentGraphIndex + 1];
-    }, [state.currentGraphIndex, state.visitedGraphsHistory]);
-
-    const selectPreviousGraph = useCallback(() => {
-        setState((prevState) => ({
-            ...prevState,
-            currentGraphIndex: Math.max(0, prevState.currentGraphIndex - 1),
-            visitedGraphsHistory: [...prevState.visitedGraphsHistory],
-        }));
-    }, []);
-
-    const selectNextGraph = useCallback(() => {
-        setState((prevState) => ({
-            ...prevState,
-            currentGraphIndex: Math.min(prevState.visitedGraphsHistory.length - 1, prevState.currentGraphIndex + 1),
-            visitedGraphsHistory: [...prevState.visitedGraphsHistory],
-        }));
-    }, []);
-
     const getOperand = useCallback(
         (edgeName: string) => {
             return state.operands.get(edgeName);
@@ -203,10 +165,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
             resetGraphOnChipState: reset,
-            getPreviousGraphName,
-            getNextGraphName,
-            selectPreviousGraph,
-            selectNextGraph,
             getOperand,
             getGraphOnChipListForTemporalEpoch,
         }),
@@ -218,10 +176,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
             reset,
-            getPreviousGraphName,
-            getNextGraphName,
-            selectPreviousGraph,
-            selectNextGraph,
             getOperand,
             getGraphOnChipListForTemporalEpoch,
         ],

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -168,9 +168,11 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                     return graph.temporalEpoch === epoch;
                 },
             );
-            return listOfGraphRel.map((graph) => {
-                return { graph, graphOnChip: state.graphOnChipList[graph.name] };
-            });
+            return listOfGraphRel
+                .map((graph) => {
+                    return { graph, graphOnChip: state.graphOnChipList[graph.name] };
+                })
+                .sort((a, b) => a.graphOnChip.chipId - b.graphOnChip.chipId);
         },
         [state.graphOnChipList, state.graphs],
     );

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -41,7 +41,6 @@ interface GraphOnChipContextType {
     selectPreviousGraph: () => void;
     selectNextGraph: () => void;
     getGraphOnChip: (graphName: string) => GraphOnChip | undefined;
-    getActiveGraphName: () => string;
     graphOnChipList: Record<string, GraphOnChip>;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getActiveGraphOnChipListForTemporalEpoch: () => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
@@ -70,7 +69,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     selectPreviousGraph: () => {},
     selectNextGraph: () => {},
     getGraphOnChip: () => undefined,
-    getActiveGraphName: () => '',
     graphOnChipList: {},
     getOperand: () => undefined,
     getActiveGraphOnChipListForTemporalEpoch: () => [],
@@ -227,11 +225,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }));
     }, []);
 
-    const getActiveGraphName = useCallback(() => {
-        return state.visitedGraphsHistory[state.currentGraphIndex] ?? '';
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [state.visitedGraphsHistory]);
-
     const getOperand = useCallback(
         (edgeName: string) => {
             return state.operands.get(edgeName);
@@ -248,7 +241,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
-            getActiveGraphName,
             resetGraphOnChipState: reset,
             getPreviousGraphName,
             getNextGraphName,
@@ -268,7 +260,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
-            getActiveGraphName,
             reset,
             getPreviousGraphName,
             getNextGraphName,

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -58,7 +58,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getGraphOnChip: () => undefined,
     getOperand: () => undefined,
     getGraphOnChipListForTemporalEpoch: () => [],
-    getTemporalEpochList: () => [],
 });
 
 const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
@@ -164,15 +163,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         );
     }, [state.graphs]);
 
-    // method to get an array of temporalepoch ids
-    const getTemporalEpochList = useCallback(() => {
-        const temporalEpochList: number[] = [];
-        state.graphs.forEach((graph) => {
-            temporalEpochList[graph.temporalEpoch] = graph.temporalEpoch;
-        });
-        return temporalEpochList.filter((epoch) => epoch !== undefined) || [];
-    }, [state.graphs]);
-
     const getGraphOnChipListForTemporalEpoch = useCallback(
         (epoch: number, chipId?: number) => {
             const graphArray = state.graphsByTemporalEpoch.get(epoch) ?? [];
@@ -207,7 +197,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             resetGraphOnChipState,
             getOperand,
             getGraphOnChipListForTemporalEpoch,
-            getTemporalEpochList,
         }),
         [
             loadGraphOnChips,
@@ -218,7 +207,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             resetGraphOnChipState,
             getOperand,
             getGraphOnChipListForTemporalEpoch,
-            getTemporalEpochList,
         ],
     );
 

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -33,7 +33,6 @@ interface GraphOnChipContextType {
     getGraphRelationshipList: () => GraphRelationship[];
     getGraphRelationshipByGraphName: (graphName: string) => GraphRelationship | undefined;
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
-    getActiveGraphRelationship: () => GraphRelationship | undefined;
     getActiveGraphOnChip: () => GraphOnChip | undefined;
     getPreviousGraphName: () => string | undefined;
     getNextGraphName: () => string | undefined;
@@ -42,7 +41,6 @@ interface GraphOnChipContextType {
     getGraphOnChip: (graphName: string) => GraphOnChip | undefined;
     graphOnChipList: Record<string, GraphOnChip>;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
-    getActiveGraphOnChipListForTemporalEpoch: () => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
 }
 
@@ -60,7 +58,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getGraphRelationshipList: () => [],
     getGraphRelationshipByGraphName: () => undefined,
     getGraphsListByTemporalEpoch: () => new Map(),
-    getActiveGraphRelationship: () => undefined,
     getActiveGraphOnChip: () => undefined,
     getPreviousGraphName: () => undefined,
     getNextGraphName: () => undefined,
@@ -69,7 +66,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getGraphOnChip: () => undefined,
     graphOnChipList: {},
     getOperand: () => undefined,
-    getActiveGraphOnChipListForTemporalEpoch: () => [],
     getGraphOnChipListForTemporalEpoch: () => [],
 });
 
@@ -146,23 +142,9 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         );
     }, [state.graphs]);
 
-    const getActiveGraphRelationship = useCallback(() => {
-        return state.graphs.get(state.visitedGraphsHistory[state.currentGraphIndex] ?? '');
-    }, [state]);
-
     const getActiveGraphOnChip = useCallback(() => {
         return state.graphOnChipList[state.visitedGraphsHistory[state.currentGraphIndex] ?? ''];
     }, [state]);
-
-    const getActiveGraphOnChipListForTemporalEpoch = useCallback(() => {
-        const epoch = getActiveGraphRelationship()?.temporalEpoch;
-        const listOfGraphRel: GraphRelationship[] = [...state.graphs.values()].filter((graph: GraphRelationship) => {
-            return graph.temporalEpoch === epoch;
-        });
-        return listOfGraphRel.map((graph) => {
-            return { graph, graphOnChip: state.graphOnChipList[graph.name] };
-        });
-    }, [getActiveGraphRelationship, state.graphOnChipList, state.graphs]);
 
     const getGraphOnChipListForTemporalEpoch = useCallback(
         (epoch: number) => {
@@ -215,7 +197,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         () => ({
             loadGraphOnChips,
             getActiveGraphOnChip,
-            getActiveGraphRelationship,
             getGraphRelationshipList,
             getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
@@ -227,13 +208,11 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             selectNextGraph,
             graphOnChipList: state.graphOnChipList,
             getOperand,
-            getActiveGraphOnChipListForTemporalEpoch,
             getGraphOnChipListForTemporalEpoch,
         }),
         [
             loadGraphOnChips,
             getActiveGraphOnChip,
-            getActiveGraphRelationship,
             getGraphRelationshipList,
             getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
@@ -245,7 +224,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             selectNextGraph,
             state.graphOnChipList,
             getOperand,
-            getActiveGraphOnChipListForTemporalEpoch,
             getGraphOnChipListForTemporalEpoch,
         ],
     );

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -33,7 +33,10 @@ interface GraphOnChipContextType {
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
     /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
     getActiveGraphOnChip: () => GraphOnChip | undefined;
-    getGraphOnChip: (temporalEpoch: number, chipId?: number) => GraphOnChip[];
+    getGraphOnChip: (
+        temporalEpoch: number,
+        chipId?: number,
+    ) => { graph: GraphOnChip; relationship: GraphRelationship }[];
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
 }
@@ -94,7 +97,7 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
     const getGraphOnChip = useCallback(
         (temporalEpoch: number, chipId?: number) => {
-            const graphs: GraphOnChip[] = [];
+            const graphs: { graph: GraphOnChip; relationship: GraphRelationship }[] = [];
 
             [...state.graphs.values()].forEach((graphRelationship) => {
                 const isSameTemporalEpoch = graphRelationship.temporalEpoch === temporalEpoch;
@@ -103,11 +106,17 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
                 if (isSameTemporalEpoch) {
                     if (!hasChipId) {
-                        graphs.push(state.graphOnChipList[graphRelationship.name]);
+                        graphs.push({
+                            graph: state.graphOnChipList[graphRelationship.name],
+                            relationship: graphRelationship,
+                        });
                     }
 
                     if (hasChipId && isSameChipId) {
-                        graphs.push(state.graphOnChipList[graphRelationship.name]);
+                        graphs.push({
+                            graph: state.graphOnChipList[graphRelationship.name],
+                            relationship: graphRelationship,
+                        });
                     }
                 }
             });

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -38,7 +38,7 @@ interface GraphOnChipContextType {
     getNextGraphName: () => string | undefined;
     selectPreviousGraph: () => void;
     selectNextGraph: () => void;
-    getGraphOnChip: (graphName: string) => GraphOnChip | undefined;
+    getGraphOnChip: (chipId: number) => GraphOnChip | undefined;
     graphOnChipList: Record<string, GraphOnChip>;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
@@ -108,8 +108,8 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }, []);
 
     const getGraphOnChip = useCallback(
-        (graphName: string) => {
-            return state.graphOnChipList[graphName];
+        (chipId: number) => {
+            return Object.values(state.graphOnChipList).find((graph) => graph.chipId === chipId);
         },
         [state.graphOnChipList],
     );

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -163,16 +163,16 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
     const getGraphOnChipListForTemporalEpoch = useCallback(
         (epoch: number) => {
-            const listOfGraphRel: GraphRelationship[] = [...state.graphs.values()].filter(
-                (graph: GraphRelationship) => {
-                    return graph.temporalEpoch === epoch;
-                },
-            );
-            return listOfGraphRel
-                .map((graph) => {
-                    return { graph, graphOnChip: state.graphOnChipList[graph.name] };
-                })
-                .sort((a, b) => a.graphOnChip.chipId - b.graphOnChip.chipId);
+            const graphArray: { graph: GraphRelationship; graphOnChip: GraphOnChip }[] = [];
+
+            state.graphs.forEach((graph) => {
+                if (graph.temporalEpoch === epoch) {
+                    const { chipId } = state.graphOnChipList[graph.name];
+                    graphArray[chipId] = { graph, graphOnChip: state.graphOnChipList[graph.name] };
+                }
+            });
+
+            return graphArray;
         },
         [state.graphOnChipList, state.graphs],
     );

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -31,6 +31,7 @@ interface GraphOnChipContextType {
     loadGraphOnChips: (newChips: GraphOnChip[], graphs: GraphRelationship[]) => void;
     resetGraphOnChipState: () => void;
     getGraphRelationshipList: () => GraphRelationship[];
+    getGraphRelationshipByGraphName: (graphName: string) => GraphRelationship | undefined;
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
     getActiveGraphRelationship: () => GraphRelationship | undefined;
     getActiveGraphOnChip: () => GraphOnChip | undefined;
@@ -59,6 +60,7 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     loadGraphOnChips: () => {},
     resetGraphOnChipState: () => {},
     getGraphRelationshipList: () => [],
+    getGraphRelationshipByGraphName: () => undefined,
     getGraphsListByTemporalEpoch: () => new Map(),
     getActiveGraphRelationship: () => undefined,
     getActiveGraphOnChip: () => undefined,
@@ -127,6 +129,11 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const getGraphRelationshipList = useCallback(() => {
         return [...state.graphs.values()];
     }, [state]);
+
+    const getGraphRelationshipByGraphName = useCallback(
+        (graphName: string) => state.graphs.get(graphName),
+        [state.graphs],
+    );
 
     const getGraphsListByTemporalEpoch = useCallback(() => {
         return [...state.graphs.values()].reduce<Map<number, GraphRelationship[]>>(
@@ -238,6 +245,7 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getActiveGraphOnChip,
             getActiveGraphRelationship,
             getGraphRelationshipList,
+            getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
             getActiveGraphName,
@@ -257,6 +265,7 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             getActiveGraphOnChip,
             getActiveGraphRelationship,
             getGraphRelationshipList,
+            getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
             getActiveGraphName,

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -33,7 +33,7 @@ interface GraphOnChipContextType {
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
     /** @deprecated Function will be removed soon, use `getGraphOnchip` instead. */
     getActiveGraphOnChip: () => GraphOnChip | undefined;
-    getGraphOnChip: (temporalEpoch: number, chipId: number) => GraphOnChip | undefined;
+    getGraphOnChip: (temporalEpoch: number, chipId?: number) => GraphOnChip[];
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
     getGraphOnChipListForTemporalEpoch: (epoch: number) => { graph: GraphRelationship; graphOnChip: GraphOnChip }[];
 }
@@ -51,7 +51,7 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     getGraphRelationshipByGraphName: () => undefined,
     getGraphsListByTemporalEpoch: () => new Map(),
     getActiveGraphOnChip: () => undefined,
-    getGraphOnChip: () => undefined,
+    getGraphOnChip: () => [],
     getOperand: () => undefined,
     getGraphOnChipListForTemporalEpoch: () => [],
 });
@@ -93,12 +93,26 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }, []);
 
     const getGraphOnChip = useCallback(
-        (temporalEpoch: number, chipId: number) => {
-            const graphRelationship = [...state.graphs.values()].find(
-                (graph) => graph.temporalEpoch === temporalEpoch && graph.chipId === chipId,
-            );
+        (temporalEpoch: number, chipId?: number) => {
+            const graphs: GraphOnChip[] = [];
 
-            return state.graphOnChipList[graphRelationship?.name ?? ''];
+            [...state.graphs.values()].forEach((graphRelationship) => {
+                const isSameTemporalEpoch = graphRelationship.temporalEpoch === temporalEpoch;
+                const hasChipId = chipId !== null && chipId !== undefined;
+                const isSameChipId = graphRelationship.chipId === chipId;
+
+                if (isSameTemporalEpoch) {
+                    if (!hasChipId) {
+                        graphs.push(state.graphOnChipList[graphRelationship.name]);
+                    }
+
+                    if (hasChipId && isSameChipId) {
+                        graphs.push(state.graphOnChipList[graphRelationship.name]);
+                    }
+                }
+            });
+
+            return graphs;
         },
         [state.graphs, state.graphOnChipList],
     );

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -27,7 +27,7 @@ export interface PipeSelectionState {
     focusPipe: string | null;
 }
 
-type TemporalEpoch = string;
+type TemporalEpoch = number;
 type NodeUID = string;
 
 export interface ComputeNodeState {
@@ -100,6 +100,6 @@ export interface ClusterViewState {
 export type FolderLocationType = 'local' | 'remote';
 
 export interface LocationState {
-    epoch: string;
+    epoch: number;
     graphName: string;
 }

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -83,7 +83,7 @@ export interface NetworkCongestionState {
         totalOps: number;
         totalOpPerChip: number[];
         normalizedTotalOps: number;
-        adjustedTotalOps: number;
+        initialNormalizedTotalOps: number;
     }[];
     CLKMHz: number;
     DRAMBandwidthGBs: number;

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -35,7 +35,7 @@ export interface ComputeNodeState {
     queueNameList: string[];
     dramGroup?: string[];
     selected: boolean;
-    graphName: string;
+    chipId: number;
 }
 
 export interface OperandSelectionState {

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -27,7 +27,6 @@ export interface PipeSelectionState {
     focusPipe: string | null;
 }
 
-type TemporalEpoch = number;
 type NodeUID = string;
 
 export interface ComputeNodeState {
@@ -47,9 +46,9 @@ export interface OperandSelectionState {
 
 export interface NodeSelectionState {
     operands: Record<NodeUID, OperandSelectionState>;
-    nodeList: Record<TemporalEpoch, Record<NodeUID, ComputeNodeState>>;
-    selectedNodeList: Record<TemporalEpoch, NodeUID[]>;
-    dramNodesHighlight: Record<TemporalEpoch, Record<NodeUID, boolean>>;
+    nodeList: Record<NodeUID, ComputeNodeState>[];
+    selectedNodeList: NodeUID[][];
+    dramNodesHighlight: Record<NodeUID, boolean>[];
     focusNode: string | null;
 }
 

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
+import type { RelativeRoutingType } from 'react-router-dom';
 import type { GraphVertexType } from './GraphNames';
 import { LinkType } from './Types';
 
@@ -102,4 +103,21 @@ export interface LocationState {
     /** @deprecated */
     graphName?: string;
     chipId?: number;
+    previous?: {
+        path: string;
+        graphName: string;
+    };
+    next?: {
+        path: string;
+        graphName: string;
+    };
+}
+
+export interface NavigateOptions {
+    replace?: boolean;
+    state?: LocationState;
+    preventScrollReset?: boolean;
+    relative?: RelativeRoutingType;
+    unstable_flushSync?: boolean;
+    unstable_viewTransition?: boolean;
 }

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -99,5 +99,7 @@ export type FolderLocationType = 'local' | 'remote';
 
 export interface LocationState {
     epoch: number;
-    graphName: string;
+    /** @deprecated */
+    graphName?: string;
+    chipId?: number;
 }

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -41,7 +41,6 @@ export interface ComputeNodeState {
 export interface OperandSelectionState {
     selected: boolean;
     type: GraphVertexType;
-    graphName: string;
 }
 
 export interface NodeSelectionState {

--- a/src/data/store/selectors/linkSaturation.selectors.ts
+++ b/src/data/store/selectors/linkSaturation.selectors.ts
@@ -19,10 +19,8 @@ export const getEpochNormalizedTotalOps = createSelector(
     (linksPerTemporalEpoch) => linksPerTemporalEpoch.map(({ normalizedTotalOps }) => normalizedTotalOps),
 );
 
-export const getEpochAdjustedTotalOps = createSelector(
-    (state: RootState) => state.linkSaturation.linksPerTemporalEpoch,
-    (linksPerTemporalEpoch) => linksPerTemporalEpoch.map(({ adjustedTotalOps }) => adjustedTotalOps),
-);
+export const getEpochInitialNormalizedTotalOps = (temporalEpoch: number) => (state: RootState) =>
+    state.linkSaturation.linksPerTemporalEpoch[temporalEpoch].initialNormalizedTotalOps;
 export const getLinkSaturation = (state: RootState) => state.linkSaturation.linkSaturationTreshold;
 export const getShowLinkSaturation = (state: RootState) => state.linkSaturation.showLinkSaturation;
 export const getShowNOC0 = (state: RootState) => state.linkSaturation.showNOC0;

--- a/src/data/store/selectors/nodeSelection.selectors.ts
+++ b/src/data/store/selectors/nodeSelection.selectors.ts
@@ -5,10 +5,10 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../createStore';
 
-export const getDramHighlightState = (temporalEpoch: string, id: string) => (state: RootState) =>
+export const getDramHighlightState = (temporalEpoch: number, id: string) => (state: RootState) =>
     state.nodeSelection.dramNodesHighlight[temporalEpoch]?.[id];
 
-export const selectNodeSelectionById = (temporalEpoch: string, id: string) => (state: RootState) =>
+export const selectNodeSelectionById = (temporalEpoch: number, id: string) => (state: RootState) =>
     state.nodeSelection.nodeList[temporalEpoch]?.[id];
 export const getOperand = (opName: string) => (state: RootState) => state.nodeSelection.operands[opName];
 
@@ -20,10 +20,10 @@ export const getOperandState = createSelector(
 export const getOperandStateList = (operandNames: string[]) => (state: RootState) =>
     operandNames.map((name) => state.nodeSelection.operands[name]);
 
-export const getSelectedNodeList = (temporalEpoch: string) => (state: RootState) =>
+export const getSelectedNodeList = (temporalEpoch: number) => (state: RootState) =>
     state.nodeSelection.nodeList[temporalEpoch];
 
-export const getOrderedNodeList = (temporalEpoch: string) => (state: RootState) =>
+export const getOrderedNodeList = (temporalEpoch: number) => (state: RootState) =>
     (state.nodeSelection.selectedNodeList[temporalEpoch] ?? [])
         .map((id) => state.nodeSelection.nodeList[temporalEpoch][id])
         .toReversed();

--- a/src/data/store/selectors/nodeSelection.selectors.ts
+++ b/src/data/store/selectors/nodeSelection.selectors.ts
@@ -23,7 +23,7 @@ export const getOperandStateList = (operandNames: string[]) => (state: RootState
 export const getSelectedNodeList = (temporalEpoch: number) => (state: RootState) =>
     state.nodeSelection.nodeList[temporalEpoch];
 
-export const getOrderedNodeList = (temporalEpoch: number) => (state: RootState) =>
+export const getOrderedSelectedNodeList = (temporalEpoch: number) => (state: RootState) =>
     (state.nodeSelection.selectedNodeList[temporalEpoch] ?? [])
         .map((id) => state.nodeSelection.nodeList[temporalEpoch][id])
         .toReversed();

--- a/src/data/store/selectors/nodeSelection.selectors.ts
+++ b/src/data/store/selectors/nodeSelection.selectors.ts
@@ -17,8 +17,10 @@ export const getOperandState = createSelector(
     (nodeSelection) => nodeSelection.operands,
 );
 
-export const getOperandStateList = (operandNames: string[]) => (state: RootState) =>
-    operandNames.map((name) => state.nodeSelection.operands[name]);
+export const getOperandStateList = createSelector(
+    (state: RootState) => state.nodeSelection,
+    (nodeSelection) => (operandNames: string[]) => operandNames.map((name) => nodeSelection.operands[name]),
+);
 
 export const getSelectedNodeList = (temporalEpoch: number) => (state: RootState) =>
     state.nodeSelection.nodeList[temporalEpoch];

--- a/src/data/store/selectors/pipeSelection.selectors.ts
+++ b/src/data/store/selectors/pipeSelection.selectors.ts
@@ -13,8 +13,11 @@ export const getFocusPipe = (state: RootState) => state.pipeSelection.focusPipe;
 export const getSelectedPipesIds = createSelector(
     (state: RootState) => Object.values(state.pipeSelection.pipes),
     (pipeSelectionStateList) =>
-        pipeSelectionStateList
-            //
-            .filter((pipe) => pipe.selected)
-            .map((pipe) => pipe.id),
+        pipeSelectionStateList.reduce((pipeIdList, pipe) => {
+            if (pipe.selected) {
+                pipeIdList.push(pipe.id);
+            }
+
+            return pipeIdList;
+        }, [] as string[]),
 );

--- a/src/data/store/selectors/uiState.selectors.ts
+++ b/src/data/store/selectors/uiState.selectors.ts
@@ -29,3 +29,4 @@ export const getDetailedViewHeight = (state: RootState) => state.uiState.detaile
 export const getDetailedViewOpenState = (state: RootState) => state.uiState.detailsViewOpen;
 
 export const getSelectedDetailsViewUID = (state: RootState) => state.uiState.selectedDetailsViewUID;
+export const getSelectedDetailsViewChipId = (state: RootState) => state.uiState.selectedDetailsViewChipId;

--- a/src/data/store/slices/nodeSelection.slice.ts
+++ b/src/data/store/slices/nodeSelection.slice.ts
@@ -61,7 +61,6 @@ const nodeSelectionSlice = createSlice({
                                 state.operands[queueName] = {
                                     selected: false,
                                     type: GraphVertexType.QUEUE,
-                                    graphName: item.graphName,
                                 };
                             }
                         });
@@ -72,7 +71,6 @@ const nodeSelectionSlice = createSlice({
                             state.operands[item.opName] = {
                                 selected: false,
                                 type: GraphVertexType.OPERATION,
-                                graphName: item.graphName,
                             };
                         }
                     }
@@ -120,52 +118,12 @@ const nodeSelectionSlice = createSlice({
                 }
             });
         },
-        selectAllOperationsForGraph(state, action: PayloadAction<string>) {
-            Object.values(state.operands).forEach((operand) => {
-                const isOperation = operand.type === GraphVertexType.OPERATION;
-                const isOnGraph = operand.graphName === action.payload;
-
-                if (isOperation && isOnGraph) {
-                    operand.selected = true;
-                }
-            });
-        },
-        clearAllOperationsForGraph(state, action: PayloadAction<string>) {
-            Object.values(state.operands).forEach((operand) => {
-                const isOperation = operand.type === GraphVertexType.OPERATION;
-                const isOnGraph = operand.graphName === action.payload;
-
-                if (isOperation && isOnGraph) {
-                    operand.selected = false;
-                }
-            });
-        },
         selectOperand(state, action: PayloadAction<{ operandName: string; selected: boolean }>) {
             const { operandName, selected } = action.payload;
 
             if (state.operands[operandName]) {
                 state.operands[operandName].selected = selected;
             }
-        },
-        selectAllQueuesForGraph(state, action: PayloadAction<string>) {
-            Object.values(state.operands).forEach((operand) => {
-                const isOperation = operand.type === GraphVertexType.QUEUE;
-                const isOnGraph = operand.graphName === action.payload;
-
-                if (isOperation && isOnGraph) {
-                    operand.selected = true;
-                }
-            });
-        },
-        clearAllQueuesforGraph(state, action: PayloadAction<string>) {
-            Object.values(state.operands).forEach((operand) => {
-                const isOperation = operand.type === GraphVertexType.QUEUE;
-                const isOnGraph = operand.graphName === action.payload;
-
-                if (isOperation && isOnGraph) {
-                    operand.selected = false;
-                }
-            });
         },
         updateFocusNode(state, action: PayloadAction<string | null>) {
             state.focusNode = action.payload;
@@ -178,11 +136,7 @@ export const {
     initialLoadAllNodesData,
     updateNodeSelection,
     selectOperandList,
-    selectAllOperationsForGraph,
-    clearAllOperationsForGraph,
     selectOperand,
-    selectAllQueuesForGraph,
-    clearAllQueuesforGraph,
     updateFocusNode,
 } = nodeSelectionSlice.actions;
 

--- a/src/data/store/slices/nodeSelection.slice.ts
+++ b/src/data/store/slices/nodeSelection.slice.ts
@@ -40,14 +40,14 @@ const nodeSelectionSlice = createSlice({
                         opName: item.opName,
                         queueNameList: item.queueNameList,
                         selected: false,
-                        graphName: item.graphName,
+                        chipId: item.chipId,
                     };
 
                     if (item.dramChannelId !== -1) {
                         const dramGroup = action.payload[epochNumber]
                             .filter(
-                                ({ dramChannelId, graphName }) =>
-                                    dramChannelId === item.dramChannelId && graphName === item.graphName,
+                                ({ dramChannelId, chipId }) =>
+                                    dramChannelId === item.dramChannelId && chipId === item.chipId,
                             )
                             .map(({ id }) => id);
 

--- a/src/data/store/slices/nodeSelection.slice.ts
+++ b/src/data/store/slices/nodeSelection.slice.ts
@@ -35,8 +35,8 @@ const nodeSelectionSlice = createSlice({
                 state.dramNodesHighlight[epochNumber] = {};
 
                 computeNodeStateList.forEach((item) => {
-                    state.nodeList[epochNumber][item.id] = {
-                        id: item.id,
+                    state.nodeList[epochNumber][item.uid] = {
+                        id: item.uid,
                         opName: item.opName,
                         queueNameList: item.queueNameList,
                         selected: false,
@@ -49,10 +49,10 @@ const nodeSelectionSlice = createSlice({
                                 ({ dramChannelId, chipId }) =>
                                     dramChannelId === item.dramChannelId && chipId === item.chipId,
                             )
-                            .map(({ id }) => id);
+                            .map(({ uid }) => uid);
 
-                        state.nodeList[epochNumber][item.id].dramGroup = dramGroup;
-                        state.dramNodesHighlight[epochNumber][item.id] = false;
+                        state.nodeList[epochNumber][item.uid].dramGroup = dramGroup;
+                        state.dramNodesHighlight[epochNumber][item.uid] = false;
                     }
 
                     if (item.queueNameList.length > 0) {

--- a/src/data/store/slices/nodeSelection.slice.ts
+++ b/src/data/store/slices/nodeSelection.slice.ts
@@ -8,9 +8,9 @@ import { GraphVertexType } from '../../GraphNames';
 import type { NodeInitialState } from '../../GraphOnChip';
 
 const nodesInitialState: NodeSelectionState = {
-    nodeList: {},
-    selectedNodeList: {},
-    dramNodesHighlight: {},
+    nodeList: [],
+    selectedNodeList: [],
+    dramNodesHighlight: [],
     operands: {},
     focusNode: null,
 };
@@ -20,10 +20,10 @@ const nodeSelectionSlice = createSlice({
     initialState: nodesInitialState,
     reducers: {
         initialLoadAllNodesData(state, action: PayloadAction<Record<number, NodeInitialState[]>>) {
-            state.nodeList = {};
-            state.selectedNodeList = {};
+            state.nodeList = [];
+            state.selectedNodeList = [];
             state.operands = {};
-            state.dramNodesHighlight = {};
+            state.dramNodesHighlight = [];
             state.focusNode = null;
 
             Object.entries(action.payload).forEach(([temporalEpoch, computeNodeStateList]) => {

--- a/src/data/store/slices/nodeSelection.slice.ts
+++ b/src/data/store/slices/nodeSelection.slice.ts
@@ -5,7 +5,7 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { NodeSelectionState } from 'data/StateTypes';
 import { GraphVertexType } from '../../GraphNames';
-import type { ComputeNode } from '../../GraphOnChip';
+import type { NodeInitialState } from '../../GraphOnChip';
 
 const nodesInitialState: NodeSelectionState = {
     nodeList: {},
@@ -19,10 +19,7 @@ const nodeSelectionSlice = createSlice({
     name: 'nodeSelection',
     initialState: nodesInitialState,
     reducers: {
-        initialLoadAllNodesData(
-            state,
-            action: PayloadAction<Record<number, ReturnType<ComputeNode['generateInitialState']>[]>>,
-        ) {
+        initialLoadAllNodesData(state, action: PayloadAction<Record<number, NodeInitialState[]>>) {
             state.nodeList = {};
             state.selectedNodeList = {};
             state.operands = {};

--- a/src/data/store/slices/nodeSelection.slice.ts
+++ b/src/data/store/slices/nodeSelection.slice.ts
@@ -21,7 +21,7 @@ const nodeSelectionSlice = createSlice({
     reducers: {
         initialLoadAllNodesData(
             state,
-            action: PayloadAction<Record<string, ReturnType<ComputeNode['generateInitialState']>[]>>,
+            action: PayloadAction<Record<number, ReturnType<ComputeNode['generateInitialState']>[]>>,
         ) {
             state.nodeList = {};
             state.selectedNodeList = {};
@@ -30,12 +30,15 @@ const nodeSelectionSlice = createSlice({
             state.focusNode = null;
 
             Object.entries(action.payload).forEach(([temporalEpoch, computeNodeStateList]) => {
-                state.nodeList[temporalEpoch] = {};
-                state.selectedNodeList[temporalEpoch] = [];
-                state.dramNodesHighlight[temporalEpoch] = {};
+                // Object.entries always return the key converted to string, we convert epoch back to a number here
+                const epochNumber = Number.parseInt(temporalEpoch, 10);
+
+                state.nodeList[epochNumber] = {};
+                state.selectedNodeList[epochNumber] = [];
+                state.dramNodesHighlight[epochNumber] = {};
 
                 computeNodeStateList.forEach((item) => {
-                    state.nodeList[temporalEpoch][item.id] = {
+                    state.nodeList[epochNumber][item.id] = {
                         id: item.id,
                         opName: item.opName,
                         queueNameList: item.queueNameList,
@@ -44,15 +47,15 @@ const nodeSelectionSlice = createSlice({
                     };
 
                     if (item.dramChannelId !== -1) {
-                        const dramGroup = action.payload[temporalEpoch]
+                        const dramGroup = action.payload[epochNumber]
                             .filter(
                                 ({ dramChannelId, graphName }) =>
                                     dramChannelId === item.dramChannelId && graphName === item.graphName,
                             )
                             .map(({ id }) => id);
 
-                        state.nodeList[temporalEpoch][item.id].dramGroup = dramGroup;
-                        state.dramNodesHighlight[temporalEpoch][item.id] = false;
+                        state.nodeList[epochNumber][item.id].dramGroup = dramGroup;
+                        state.dramNodesHighlight[epochNumber][item.id] = false;
                     }
 
                     if (item.queueNameList.length > 0) {
@@ -80,7 +83,7 @@ const nodeSelectionSlice = createSlice({
             });
         },
 
-        updateNodeSelection(state, action: PayloadAction<{ temporalEpoch: string; id: string; selected: boolean }>) {
+        updateNodeSelection(state, action: PayloadAction<{ temporalEpoch: number; id: string; selected: boolean }>) {
             const { temporalEpoch, id, selected } = action.payload;
             const node = state.nodeList?.[temporalEpoch]?.[id];
 

--- a/src/data/store/slices/uiState.slice.ts
+++ b/src/data/store/slices/uiState.slice.ts
@@ -12,7 +12,8 @@ import { INITIAL_DETAILS_VIEW_HEIGHT } from '../../constants';
 interface UIState {
     dockOpen: boolean;
     detailsViewOpen: boolean;
-    selectedDetailsViewUID: string | null;
+    selectedDetailsViewUID?: string;
+    selectedDetailsViewChipId?: number;
     highContrastEnabled: boolean;
     folderPath: string;
     selectedRemoteFolder?: RemoteFolder;
@@ -30,7 +31,8 @@ interface UIState {
 const uiStateInitialState: UIState = {
     dockOpen: false,
     detailsViewOpen: false,
-    selectedDetailsViewUID: null,
+    selectedDetailsViewUID: undefined,
+    selectedDetailsViewChipId: undefined,
     highContrastEnabled: false,
     folderPath: '',
     selectedRemoteFolder: undefined,
@@ -94,14 +96,16 @@ const uiStateSlice = createSlice({
         updateDetailedViewHeight: (state, action: PayloadAction<number>) => {
             state.detailedViewHeight = action.payload;
         },
-        openDetailedView: (state, action: PayloadAction<string>) => {
+        openDetailedView: (state, action: PayloadAction<{ nodeUid: string; chipId: number }>) => {
             state.detailsViewOpen = true;
             state.dockOpen = false;
-            state.selectedDetailsViewUID = action.payload;
+            state.selectedDetailsViewUID = action.payload.nodeUid;
+            state.selectedDetailsViewChipId = action.payload.chipId;
         },
         closeDetailedView: (state) => {
             state.detailsViewOpen = false;
-            state.selectedDetailsViewUID = null;
+            state.selectedDetailsViewUID = undefined;
+            state.selectedDetailsViewChipId = undefined;
         },
     },
 });

--- a/src/renderer/components/GridRender.tsx
+++ b/src/renderer/components/GridRender.tsx
@@ -23,9 +23,9 @@ export default function GridRender() {
     const gridZoom = useSelector(getGridZoom);
     const { error } = usePerfAnalyzerFileLoader();
     const location: Location<LocationState> = useLocation();
-    const { graphName = '', epoch } = location.state;
+    const { graphName = '', chipId = -1, epoch } = location.state;
 
-    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(graphName);
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(chipId);
     const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(epoch);
 
     const style =
@@ -39,7 +39,7 @@ export default function GridRender() {
 
     return (
         <div className='main-content' style={style}>
-            {graphOnChip && (
+            {graphOnChip ? (
                 <div className='grid-container'>
                     <div
                         className='node-container'
@@ -62,8 +62,8 @@ export default function GridRender() {
                         ]}
                     </div>
                 </div>
-            )}
-            {!graphName && (graphList.map((data) => {
+            ) : (
+                graphList.map((data) => {
                     return (
                         <div className='grid-container'>
                             <div
@@ -86,8 +86,8 @@ export default function GridRender() {
                             </div>
                         </div>
                     );
-                }
-            ))}
+                })
+            )}
             {graphOnChip === undefined && graphList.length === 0 && (
                 <div className='invalid-data-message'>
                     <Icon icon={IconNames.WARNING_SIGN} size={50} />

--- a/src/renderer/components/GridRender.tsx
+++ b/src/renderer/components/GridRender.tsx
@@ -63,32 +63,31 @@ export default function GridRender() {
                     </div>
                 </div>
             )}
-
-            {graphList.map((data) => {
-                return (
-                    <div className='grid-container'>
-                        <div
-                            className='node-container'
-                            style={{
-                                zoom: `${gridZoom}`,
-                                gridTemplateColumns: `repeat(${data.graphOnChip.totalCols + 1}, ${NODE_SIZE}px)`,
-                            }}
-                        >
-                            {[...data.graphOnChip.nodes].map((node: ComputeNode) => {
-                                // console.log('render node');
-                                return (
-                                    <NodeGridElement
-                                        node={node}
-                                        temporalEpoch={epoch}
-                                        graphName={data.graph.name}
-                                        key={node.uid}
-                                    />
-                                );
-                            })}
+            {!graphName && (graphList.map((data) => {
+                    return (
+                        <div className='grid-container'>
+                            <div
+                                className='node-container'
+                                style={{
+                                    zoom: `${gridZoom}`,
+                                    gridTemplateColumns: `repeat(${data.graphOnChip.totalCols + 1}, ${NODE_SIZE}px)`,
+                                }}
+                            >
+                                {[...data.graphOnChip.nodes].map((node: ComputeNode) => {
+                                    return (
+                                        <NodeGridElement
+                                            node={node}
+                                            temporalEpoch={epoch}
+                                            graphName={data.graph.name}
+                                            key={node.uid}
+                                        />
+                                    );
+                                })}
+                            </div>
                         </div>
-                    </div>
-                );
-            })}
+                    );
+                }
+            ))}
             {graphOnChip === undefined && graphList.length === 0 && (
                 <div className='invalid-data-message'>
                     <Icon icon={IconNames.WARNING_SIGN} size={50} />

--- a/src/renderer/components/GridRender.tsx
+++ b/src/renderer/components/GridRender.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import { CSSProperties, useContext } from 'react';
+import { CSSProperties, useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Icon } from '@blueprintjs/core';
@@ -27,6 +27,10 @@ export default function GridRender() {
 
     const graphOnChipList = useContext(GraphOnChipContext).getGraphOnChip(epoch, chipId);
     const { cluster } = useContext(ClusterContext);
+    const clusterChipsMap = useMemo(
+        () => Object.fromEntries((cluster?.chips ?? []).map((chip) => [chip.id, chip])),
+        [cluster],
+    );
 
     const style =
         graphOnChipList.length > 1
@@ -40,13 +44,16 @@ export default function GridRender() {
     return (
         <div className='main-content' style={style}>
             {graphOnChipList.map(({ graph: { chipId: id, totalCols, nodes }, relationship: { name: graphName } }) => {
-                const clusterChip = cluster?.chips.find((chip) => chip.id === id);
+                const clusterChip = clusterChipsMap[id];
                 const clusterChipPositioning: CSSProperties = {};
+
                 if (clusterChip) {
                     clusterChipPositioning.gridColumn = clusterChip.coordinates.x + 1;
                     clusterChipPositioning.gridRow = clusterChip.coordinates.y + 1;
                 }
+
                 clusterChipPositioning.contentVisibility = 'auto';
+
                 return (
                     <div className='grid-container' style={clusterChipPositioning}>
                         <div

--- a/src/renderer/components/GridRender.tsx
+++ b/src/renderer/components/GridRender.tsx
@@ -23,7 +23,7 @@ export default function GridRender() {
     const gridZoom = useSelector(getGridZoom);
     const { error } = usePerfAnalyzerFileLoader();
     const location: Location<LocationState> = useLocation();
-    const { graphName, epoch } = location.state;
+    const { graphName = '', epoch } = location.state;
 
     const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(graphName);
     const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(epoch);

--- a/src/renderer/components/GridRender.tsx
+++ b/src/renderer/components/GridRender.tsx
@@ -25,7 +25,7 @@ export default function GridRender() {
     const location: Location<LocationState> = useLocation();
     const { graphName = '', chipId = -1, epoch } = location.state;
 
-    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(chipId);
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch, chipId);
     const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(epoch);
 
     const style =

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -27,6 +27,7 @@ import OffChipNodeLinkCongestionLayer from './node-grid-elements-components/OffC
 import { getShowOperationPerformanceGrid } from '../../data/store/selectors/operationPerf.selectors';
 import { getAllLinksForGraph, getShowLinkSaturation } from '../../data/store/selectors/linkSaturation.selectors';
 import NodePipeRenderer from './node-grid-elements-components/NodePipeRenderer';
+import NodeFocusPipeRenderer from './node-grid-elements-components/NodeFocusPipeRenderer';
 
 interface NodeGridElementProps {
     node: ComputeNode;
@@ -141,7 +142,8 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
                 showLinkSaturation={showLinkSaturation}
                 linksData={linksData}
             />
-            {/* <NodeFocusPipeRenderer node={node} /> */}
+            <NodeFocusPipeRenderer node={node} />
+
             {/* Node type label */}
             <div className={`node-type-label node-type-${node.getNodeLabel()}`}>{node.getNodeLabel()}</div>
         </button>

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -57,9 +57,12 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
     const shouldShowLabel = !node.opSiblingNodes?.top && !node.opSiblingNodes?.left;
 
     let coreHighlight = HighlightType.NONE;
-    // TODO: invert logic to avoid recomputing consumer/producer cores. Simply check if the node id matches
-    const isConsumer = node.consumerPipes.filter((pipe) => pipe.id === focusPipe).length > 0; // ?.consumerCores.includes(node.uid);
-    const isProducer = node.producerPipes.filter((pipe) => pipe.id === focusPipe).length > 0; // ?.consumerCores.includes(node.uid);
+    const nodeConsumerPipeMap = useMemo(() => [...new Set(node.consumerPipes.map((pipe) => pipe.id))], [node]);
+    const nodeProducerPipeMap = useMemo(() => [...new Set(node.producerPipes.map((pipe) => pipe.id))], [node]);
+
+    const isConsumer = nodeConsumerPipeMap.includes(focusPipe ?? '');
+    const isProducer = nodeProducerPipeMap.includes(focusPipe ?? '');
+
     if (isConsumer && isProducer) {
         coreHighlight = HighlightType.BOTH;
     } else if (isConsumer) {

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -65,7 +65,7 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
     const triggerSelection = () => {
         const selectedState = nodeState?.selected;
         if (isOpen && selectedState) {
-            dispatch(openDetailedView(node.uid));
+            dispatch(openDetailedView({ nodeUid: node.uid, chipId: node.chipId }));
         } else {
             dispatch(updateNodeSelection({ temporalEpoch, id: node.uid, selected: !nodeState?.selected }));
         }

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -57,11 +57,9 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
     const shouldShowLabel = !node.opSiblingNodes?.top && !node.opSiblingNodes?.left;
 
     let coreHighlight = HighlightType.NONE;
-    const nodeConsumerPipeMap = useMemo(() => [...new Set(node.consumerPipes.map((pipe) => pipe.id))], [node]);
-    const nodeProducerPipeMap = useMemo(() => [...new Set(node.producerPipes.map((pipe) => pipe.id))], [node]);
 
-    const isConsumer = nodeConsumerPipeMap.includes(focusPipe ?? '');
-    const isProducer = nodeProducerPipeMap.includes(focusPipe ?? '');
+    const isConsumer = node.consumerPipes.find(({ id }) => id === focusPipe) !== undefined;
+    const isProducer = node.producerPipes.find(({ id }) => id === focusPipe) !== undefined;
 
     if (isConsumer && isProducer) {
         coreHighlight = HighlightType.BOTH;

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -5,10 +5,10 @@
 import { selectNodeSelectionById } from 'data/store/selectors/nodeSelection.selectors';
 import { updateNodeSelection } from 'data/store/slices/nodeSelection.slice';
 import { openDetailedView } from 'data/store/slices/uiState.slice';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ComputeNode } from '../../data/GraphOnChip';
-import { EthernetLinkName, HighlightType } from '../../data/Types';
+import { HighlightType } from '../../data/Types';
 import { getFocusPipe } from '../../data/store/selectors/pipeSelection.selectors';
 import {
     getDetailedViewOpenState,
@@ -80,18 +80,6 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
         }
     };
 
-    // TODO: pre-calculate external pipes
-    const externalPipes = useMemo(() => {
-        if (connectedEth === null) {
-            return [];
-        }
-        return node
-            .getInternalLinksForNode()
-            .filter((link) => link.name === EthernetLinkName.ETH_IN || link.name === EthernetLinkName.ETH_OUT)
-            .map((link) => link.pipes)
-            .flat();
-    }, [connectedEth, node]);
-
     return (
         <button
             title={showOperationNames && shouldShowLabel ? node.opName : ''}
@@ -101,7 +89,7 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
             } `}
             onClick={triggerSelection}
         >
-            {connectedEth !== null && externalPipes.length > 0 && (
+            {connectedEth !== null && node.externalPipes.length > 0 && (
                 <div className='eth-connection'>
                     {/* TEMPORARY OTPUT */}
                     <span>ETH {connectedEth?.id}</span>

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -32,7 +32,6 @@ interface NodeGridElementProps {
 }
 
 const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temporalEpoch }) => {
-    // const graphName = useContext(GraphOnChipContext).getActiveGraphName();
     const dispatch = useDispatch();
     const nodeState = useSelector(selectNodeSelectionById(temporalEpoch, node.uid));
     const isOpen = useSelector(getDetailedViewOpenState);

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -112,7 +112,7 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
 
             {/* Congestion information */}
             <OperationCongestionLayer node={node} />
-            <OffChipNodeLinkCongestionLayer node={node} />
+            <OffChipNodeLinkCongestionLayer node={node} graphName={graphName} />
 
             {/* Labels for location and operation */}
             <NodeLocation node={node} />

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -43,12 +43,11 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
     const isOpen = useSelector(getDetailedViewOpenState);
     const uid = useSelector(getSelectedDetailsViewUID);
     const focusPipe = useSelector(getFocusPipe);
-
-    // TODO: move to grid rendering
     const showOperationNames = useSelector(getShowOperationNames);
     const shouldRenderOpPerf = useSelector(getShowOperationPerformanceGrid);
     const isHighContrast = useSelector(getHighContrastState);
     const showLinkSaturation = useSelector(getShowLinkSaturation);
+
     // TODO: pre-calculate link saturation and memoize it
     const linksData = useSelector(getAllLinksForGraph(graphName));
 
@@ -58,6 +57,7 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
     const shouldShowLabel = !node.opSiblingNodes?.top && !node.opSiblingNodes?.left;
 
     let coreHighlight = HighlightType.NONE;
+    // TODO: invert logic to avoid recomputing consumer/producer cores. Simply check if the node id matches
     const isConsumer = node.consumerPipes.filter((pipe) => pipe.id === focusPipe).length > 0; // ?.consumerCores.includes(node.uid);
     const isProducer = node.producerPipes.filter((pipe) => pipe.id === focusPipe).length > 0; // ?.consumerCores.includes(node.uid);
     if (isConsumer && isProducer) {
@@ -67,8 +67,6 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
     } else if (isProducer) {
         coreHighlight = HighlightType.INPUT;
     }
-
-    // console.log(nodeState)
 
     const highlightClass = coreHighlight === HighlightType.NONE ? '' : `core-highlight-${coreHighlight}`;
 
@@ -81,6 +79,7 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temp
         }
     };
 
+    // TODO: pre-calculate external pipes
     const externalPipes = useMemo(() => {
         if (connectedEth === null) {
             return [];

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -28,7 +28,7 @@ import NodeFocusPipeRenderer from './node-grid-elements-components/NodeFocusPipe
 interface NodeGridElementProps {
     node: ComputeNode;
     graphName: string;
-    temporalEpoch: string;
+    temporalEpoch: number;
 }
 
 const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, graphName, temporalEpoch }) => {

--- a/src/renderer/components/PipeInfoDialog.tsx
+++ b/src/renderer/components/PipeInfoDialog.tsx
@@ -6,9 +6,11 @@ import { Icon, Position } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import React, { FC, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import { type Location, useLocation } from 'react-router-dom';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 
 import './PipeInfoDialog.scss';
+import type { LocationState } from '../../data/StateTypes';
 
 export interface PipeInfoDialogProps {
     pipeId: string;
@@ -22,7 +24,10 @@ export interface PipeInfoDialogProps {
  * @description This wrapper component is used to display information about a Pipe Segment when the user hovers over it
  */
 const PipeInfoDialog: FC<PropsWithChildren<PipeInfoDialogProps>> = ({ children, pipeId, hide, onEnter, onLeave }) => {
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
+    const location: Location<LocationState> = useLocation();
+    const { epoch } = location.state;
+    // TODO: use multiple graphs
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch)[0]?.graph;
     const [tooltipContent, setTooltipContent] = useState<React.JSX.Element | undefined>(undefined);
 
     const setupData = () => {

--- a/src/renderer/components/SideBar.tsx
+++ b/src/renderer/components/SideBar.tsx
@@ -10,15 +10,17 @@ import { getApplicationMode, getDetailedViewOpenState, getDockOpenState } from '
 import { setDockOpenState, setSelectedFile, setSelectedFolder } from 'data/store/slices/uiState.slice';
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { type Location, useLocation, useNavigate } from 'react-router-dom';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 import { ClusterContext } from '../../data/ClusterContext';
 import { openClusterView } from '../../data/store/slices/clusterView.slice';
+import type { LocationState, NavigateOptions } from '../../data/StateTypes';
 
 export interface SideBarProps {}
 
 export const SideBar: React.FC<SideBarProps> = () => {
     const { resetGraphOnChipState } = useContext(GraphOnChipContext);
+    const location: Location<LocationState> = useLocation();
     const navigate = useNavigate();
     const applicationMode = useSelector(getApplicationMode);
     const { cluster } = useContext(ClusterContext);
@@ -27,7 +29,15 @@ export const SideBar: React.FC<SideBarProps> = () => {
         resetGraphOnChipState();
         dispatch(setSelectedFile(''));
         dispatch(setSelectedFolder(''));
-        navigate('/');
+        navigate('/', {
+            state: {
+                epoch: -1,
+                previous: {
+                    graphName: location.state.graphName ?? '',
+                    path: location.pathname,
+                },
+            },
+        } satisfies NavigateOptions);
     };
 
     const handleOpenClusterView = () => {

--- a/src/renderer/components/SideBar.tsx
+++ b/src/renderer/components/SideBar.tsx
@@ -33,7 +33,7 @@ export const SideBar: React.FC<SideBarProps> = () => {
             state: {
                 epoch: -1,
                 previous: {
-                    graphName: location.state.graphName ?? '',
+                    graphName: location.state?.graphName ?? '',
                     path: location.pathname,
                 },
             },

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -14,8 +14,9 @@ import {
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AnchorButton } from '@blueprintjs/core';
+import { type Location, useLocation } from 'react-router-dom';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
-import type { FolderLocationType } from '../../data/StateTypes';
+import type { FolderLocationType, LocationState } from '../../data/StateTypes';
 import { setSelectedRemoteFolder } from '../../data/store/slices/uiState.slice';
 import { checkLocalFolderExists } from '../../utils/FileLoaders';
 import usePerfAnalyzerFileLoader from '../hooks/usePerfAnalyzerFileLoader.hooks';
@@ -44,17 +45,17 @@ const formatRemoteFolderName = (connection?: RemoteConnection, folder?: RemoteFo
 
 const TopHeaderComponent: React.FC = () => {
     const {
-        getActiveGraphName,
         resetGraphOnChipState,
-        getActiveGraphRelationship,
         getActiveGraphOnChip,
         graphOnChipList,
+        // TODO: move those calls to navigation
         selectPreviousGraph,
         selectNextGraph,
         getPreviousGraphName,
         getNextGraphName,
     } = useContext(GraphOnChipContext);
-    const { loadPerfAnalyzerFolder, openPerfAnalyzerFolderDialog, loadPerfAnalyzerGraph, loadTemporalEpoch } = usePerfAnalyzerFileLoader();
+    const { loadPerfAnalyzerFolder, openPerfAnalyzerFolderDialog, loadPerfAnalyzerGraph, loadTemporalEpoch } =
+        usePerfAnalyzerFileLoader();
     const dispatch = useDispatch();
 
     const localFolderPath = useSelector(getFolderPathSelector);
@@ -66,13 +67,12 @@ const TopHeaderComponent: React.FC = () => {
         .getSavedRemoteFolders(remoteConnectionConfig.selectedConnection)
         .filter((folder) => folder.lastSynced);
     const selectedRemoteFolder = useSelector(getSelectedRemoteFolder) ?? availableRemoteFolders[0];
-    const selectedGraph = getActiveGraphName();
     const availableGraphs = Object.keys(graphOnChipList);
-    const chipId = getActiveGraphOnChip()?.chipId;
     const architecture = getActiveGraphOnChip()?.architecture;
-    const temporalEpoch = getActiveGraphRelationship()?.temporalEpoch;
+    const location: Location<LocationState> = useLocation();
+    const { chipId, epoch: temporalEpoch } = location.state;
 
-    if (!selectedGraph && availableGraphs.length > 0) {
+    if (!chipId && !temporalEpoch && availableGraphs.length > 0) {
         loadPerfAnalyzerGraph(availableGraphs[0]);
     }
 
@@ -170,26 +170,22 @@ const TopHeaderComponent: React.FC = () => {
             </div>
 
             <div className='text-content'>
-                {selectedGraph && architecture && (
+                {architecture && (
                     <>
                         <span>Architecture:</span>
                         <span className='architecture-label'>{architecture}</span>
                     </>
                 )}
 
-                {selectedGraph && chipId !== undefined && (
+                {chipId !== undefined && (
                     <>
                         <span>Chip:</span>
                         <span>{chipId}</span>
                     </>
                 )}
 
-                {selectedGraph && temporalEpoch !== undefined && (
-                    <>
-                        <span>Epoch:</span>
-                        <span>{temporalEpoch}</span>
-                    </>
-                )}
+                <span>Epoch:</span>
+                <span>{temporalEpoch}</span>
             </div>
         </div>
     );

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -14,7 +14,7 @@ import {
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AnchorButton } from '@blueprintjs/core';
-import { type Location, useLocation } from 'react-router-dom';
+import { type Location, useLocation, useNavigate, useNavigationType } from 'react-router-dom';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 import type { FolderLocationType, LocationState } from '../../data/StateTypes';
 import { setSelectedRemoteFolder } from '../../data/store/slices/uiState.slice';
@@ -44,16 +44,12 @@ const formatRemoteFolderName = (connection?: RemoteConnection, folder?: RemoteFo
 };
 
 const TopHeaderComponent: React.FC = () => {
-    const {
-        resetGraphOnChipState,
-        getActiveGraphOnChip,
-        graphOnChipList,
-        // TODO: move those calls to navigation
-        selectPreviousGraph,
-        selectNextGraph,
-        getPreviousGraphName,
-        getNextGraphName,
-    } = useContext(GraphOnChipContext);
+    const navigate = useNavigate();
+    const navigationType = useNavigationType();
+    // TODO: find out how to properly disable buttons
+    console.log(navigationType);
+
+    const { resetGraphOnChipState, getGraphOnChip } = useContext(GraphOnChipContext);
     const { loadPerfAnalyzerFolder, openPerfAnalyzerFolderDialog, loadPerfAnalyzerGraph, loadTemporalEpoch } =
         usePerfAnalyzerFileLoader();
     const dispatch = useDispatch();
@@ -67,14 +63,9 @@ const TopHeaderComponent: React.FC = () => {
         .getSavedRemoteFolders(remoteConnectionConfig.selectedConnection)
         .filter((folder) => folder.lastSynced);
     const selectedRemoteFolder = useSelector(getSelectedRemoteFolder) ?? availableRemoteFolders[0];
-    const availableGraphs = Object.keys(graphOnChipList);
-    const architecture = getActiveGraphOnChip()?.architecture;
     const location: Location<LocationState> = useLocation();
     const { chipId, epoch: temporalEpoch } = location.state;
-
-    if (!chipId && !temporalEpoch && availableGraphs.length > 0) {
-        loadPerfAnalyzerGraph(availableGraphs[0]);
-    }
+    const architecture = getGraphOnChip(temporalEpoch, chipId ?? 0)?.architecture;
 
     const updateSelectedFolder = async (
         newFolder: RemoteFolder | string,
@@ -143,29 +134,11 @@ const TopHeaderComponent: React.FC = () => {
                     onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
                     onSelectTemporalEpoch={(newTemporalEpoch) => loadTemporalEpoch(newTemporalEpoch)}
                 />
-                <Tooltip2
-                    disabled={!getPreviousGraphName()}
-                    content={`Back to graph: ${getPreviousGraphName()}`}
-                    placement='bottom'
-                >
-                    <AnchorButton
-                        minimal
-                        disabled={!getPreviousGraphName()}
-                        icon={IconNames.ARROW_LEFT}
-                        onClick={() => selectPreviousGraph()}
-                    />
+                <Tooltip2 disabled={false} content={`Back to graph: ${'Previous graph'}`} placement='bottom'>
+                    <AnchorButton minimal disabled={false} icon={IconNames.ARROW_LEFT} onClick={() => navigate(-1)} />
                 </Tooltip2>
-                <Tooltip2
-                    disabled={!getNextGraphName()}
-                    content={`Forward to graph: ${getNextGraphName()}`}
-                    placement='bottom'
-                >
-                    <AnchorButton
-                        minimal
-                        disabled={!getNextGraphName()}
-                        icon={IconNames.ARROW_RIGHT}
-                        onClick={() => selectNextGraph()}
-                    />
+                <Tooltip2 disabled={false} content={`Forward to graph: ${'Next graph'}`} placement='bottom'>
+                    <AnchorButton minimal disabled={false} icon={IconNames.ARROW_RIGHT} onClick={() => navigate(1)} />
                 </Tooltip2>
             </div>
 

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -76,7 +76,7 @@ const TopHeaderComponent: React.FC = () => {
         loadPerfAnalyzerGraph({
             epoch: temporalEpoch ?? 0,
             graphName: availableGraphs[0],
-            chipId,
+            chipId: chipId ?? 0,
         });
     }
 
@@ -144,8 +144,8 @@ const TopHeaderComponent: React.FC = () => {
                     />
                 </Tooltip2>
                 <GraphSelector
-                    onSelectGraph={(state) => loadPerfAnalyzerGraph(state)}
-                    onSelectTemporalEpoch={(state) => loadTemporalEpoch(state)}
+                    onSelectGraph={(graphParams) => loadPerfAnalyzerGraph(graphParams)}
+                    onSelectTemporalEpoch={(epochParams) => loadTemporalEpoch(epochParams)}
                 />
                 <Tooltip2
                     disabled={!getPreviousGraphName()}

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -62,7 +62,9 @@ const TopHeaderComponent: React.FC = () => {
     const selectedRemoteFolder = useSelector(getSelectedRemoteFolder) ?? availableRemoteFolders[0];
     const location: Location<LocationState> = useLocation();
     const { chipId, epoch: temporalEpoch } = location.state;
-    const architecture = getGraphOnChip(temporalEpoch, chipId ?? 0)?.architecture;
+    const architecture = [
+        ...new Set(getGraphOnChip(temporalEpoch, chipId).map(({ graph }) => graph.architecture)),
+    ].join(', ');
 
     const updateSelectedFolder = async (
         newFolder: RemoteFolder | string,

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -14,7 +14,7 @@ import {
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AnchorButton } from '@blueprintjs/core';
-import { type Location, useLocation, useNavigate, useNavigationType } from 'react-router-dom';
+import { type Location, useLocation, useNavigate } from 'react-router-dom';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 import type { FolderLocationType, LocationState } from '../../data/StateTypes';
 import { setSelectedRemoteFolder } from '../../data/store/slices/uiState.slice';
@@ -45,9 +45,6 @@ const formatRemoteFolderName = (connection?: RemoteConnection, folder?: RemoteFo
 
 const TopHeaderComponent: React.FC = () => {
     const navigate = useNavigate();
-    const navigationType = useNavigationType();
-    // TODO: find out how to properly disable buttons
-    console.log(navigationType);
 
     const { resetGraphOnChipState, getGraphOnChip } = useContext(GraphOnChipContext);
     const { loadPerfAnalyzerFolder, openPerfAnalyzerFolderDialog, loadPerfAnalyzerGraph, loadTemporalEpoch } =
@@ -134,10 +131,10 @@ const TopHeaderComponent: React.FC = () => {
                     onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
                     onSelectTemporalEpoch={(newTemporalEpoch) => loadTemporalEpoch(newTemporalEpoch)}
                 />
-                <Tooltip2 disabled={false} content={`Back to graph: ${'Previous graph'}`} placement='bottom'>
+                <Tooltip2 disabled={false} content='Back to previous graph' placement='bottom'>
                     <AnchorButton minimal disabled={false} icon={IconNames.ARROW_LEFT} onClick={() => navigate(-1)} />
                 </Tooltip2>
-                <Tooltip2 disabled={false} content={`Forward to graph: ${'Next graph'}`} placement='bottom'>
+                <Tooltip2 disabled={false} content='Forward next graph' placement='bottom'>
                     <AnchorButton minimal disabled={false} icon={IconNames.ARROW_RIGHT} onClick={() => navigate(1)} />
                 </Tooltip2>
             </div>

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -73,7 +73,11 @@ const TopHeaderComponent: React.FC = () => {
     const temporalEpoch = getActiveGraphRelationship()?.temporalEpoch;
 
     if (!selectedGraph && availableGraphs.length > 0) {
-        loadPerfAnalyzerGraph(availableGraphs[0], temporalEpoch ?? -1);
+        loadPerfAnalyzerGraph({
+            epoch: temporalEpoch ?? 0,
+            graphName: availableGraphs[0],
+            chipId,
+        });
     }
 
     const updateSelectedFolder = async (
@@ -140,8 +144,8 @@ const TopHeaderComponent: React.FC = () => {
                     />
                 </Tooltip2>
                 <GraphSelector
-                    onSelectGraph={(graph, newTemporalEpoch) => loadPerfAnalyzerGraph(graph, newTemporalEpoch)}
-                    onSelectTemporalEpoch={(newTemporalEpoch) => loadTemporalEpoch(newTemporalEpoch)}
+                    onSelectGraph={(state) => loadPerfAnalyzerGraph(state)}
+                    onSelectTemporalEpoch={(state) => loadTemporalEpoch(state)}
                 />
                 <Tooltip2
                     disabled={!getPreviousGraphName()}

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -73,11 +73,7 @@ const TopHeaderComponent: React.FC = () => {
     const temporalEpoch = getActiveGraphRelationship()?.temporalEpoch;
 
     if (!selectedGraph && availableGraphs.length > 0) {
-        loadPerfAnalyzerGraph({
-            epoch: temporalEpoch ?? 0,
-            graphName: availableGraphs[0],
-            chipId: chipId ?? 0,
-        });
+        loadPerfAnalyzerGraph(availableGraphs[0]);
     }
 
     const updateSelectedFolder = async (
@@ -144,8 +140,8 @@ const TopHeaderComponent: React.FC = () => {
                     />
                 </Tooltip2>
                 <GraphSelector
-                    onSelectGraph={(graphParams) => loadPerfAnalyzerGraph(graphParams)}
-                    onSelectTemporalEpoch={(epochParams) => loadTemporalEpoch(epochParams)}
+                    onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
+                    onSelectTemporalEpoch={(newTemporalEpoch) => loadTemporalEpoch(newTemporalEpoch)}
                 />
                 <Tooltip2
                     disabled={!getPreviousGraphName()}

--- a/src/renderer/components/bottom-dock/BottomDock.tsx
+++ b/src/renderer/components/bottom-dock/BottomDock.tsx
@@ -26,24 +26,28 @@ const BottomDock: FC<BottomDockProps> = ({ isActive }) => {
 
     return (
         <div className='dock bottom-dock'>
-            <Tabs
-                key={isActive ? 'active-dock-tabs-key' : 'inactive-dock-tabs-key'}
-                id='dock-tabs'
-                selectedTabId={selectedTab}
-                onChange={setSelectedTab}
-                className={Classes.TABS}
-                renderActiveTabPanelOnly
-            >
-                <Tab id='tab1' title='Operations' panel={<OperationsTable />} />
-                <Tab id='tab2' title='Queues' panel={<QueuesTable />} />
-                {isLogOutputEnabled && <Tab id='tab3' title='Logs' panel={<LogsOutput />} />}
-            </Tabs>
-            <Button
-                minimal
-                icon={IconNames.CROSS}
-                className='dock-close-button'
-                onClick={() => dispatch(setDockOpenState(false))}
-            />
+            {isActive && (
+                <>
+                    <Tabs
+                        key={isActive ? 'active-dock-tabs-key' : 'inactive-dock-tabs-key'}
+                        id='dock-tabs'
+                        selectedTabId={selectedTab}
+                        onChange={setSelectedTab}
+                        className={Classes.TABS}
+                        renderActiveTabPanelOnly
+                    >
+                        <Tab id='tab1' title='Operations' panel={<OperationsTable />} />
+                        <Tab id='tab2' title='Queues' panel={<QueuesTable />} />
+                        {isLogOutputEnabled && <Tab id='tab3' title='Logs' panel={<LogsOutput />} />}
+                    </Tabs>
+                    <Button
+                        minimal
+                        icon={IconNames.CROSS}
+                        className='dock-close-button'
+                        onClick={() => dispatch(setDockOpenState(false))}
+                    />
+                </>
+            )}
         </div>
     );
 };

--- a/src/renderer/components/bottom-dock/OperationsTable.tsx
+++ b/src/renderer/components/bottom-dock/OperationsTable.tsx
@@ -36,10 +36,10 @@ import type { LocationState } from '../../../data/StateTypes';
 // TODO: This component will benefit from refactoring. in the interest of introducing a useful feature sooner this is staying as is for now.
 function OperationsTable() {
     const location: Location<LocationState> = useLocation();
-    const { epoch: temporalEpoch } = location.state;
+    const { epoch: temporalEpoch, chipId = -1 } = location.state;
     const dispatch = useDispatch();
-    const { getActiveGraphOnChip } = useContext(GraphOnChipContext);
-    const graphOnChip = getActiveGraphOnChip();
+    const { getGraphOnChip } = useContext(GraphOnChipContext);
+    const graphOnChip = getGraphOnChip(temporalEpoch, chipId);
     const { operationsTableColumns, sortTableFields, changeSorting, sortDirection, sortingColumn } =
         useOperationsTable();
     const [selectedOperationName, setSelectedOperationName] = useState('');

--- a/src/renderer/components/bottom-dock/OperationsTable.tsx
+++ b/src/renderer/components/bottom-dock/OperationsTable.tsx
@@ -139,7 +139,7 @@ function OperationsTable() {
                         dispatch(
                             updateNodeSelection({
                                 temporalEpoch,
-                                id: cellContent.toString(),
+                                id: cellContent,
                                 selected: e.target.checked,
                             }),
                         );

--- a/src/renderer/components/bottom-dock/QueuesTable.tsx
+++ b/src/renderer/components/bottom-dock/QueuesTable.tsx
@@ -31,15 +31,22 @@ function QueuesTable() {
             return [];
         }
 
-        const list = graphOnChipList.flatMap(({ graph }) =>
-            [...graph.queues].map(
-                (queue) =>
-                    ({
-                        name: queue.name,
-                        ...queue.details,
-                    }) as unknown as QueuesTableFields,
-            ),
-        );
+        const list = [
+            ...graphOnChipList
+                .reduce((queueMap, { graph }) => {
+                    [...graph.queues].forEach((queue) => {
+                        if (!queueMap.has(queue.name)) {
+                            queueMap.set(queue.name, {
+                                name: queue.name,
+                                ...queue.details,
+                            } as unknown as QueuesTableFields);
+                        }
+                    });
+
+                    return queueMap;
+                }, new Map<string, QueuesTableFields>())
+                .values(),
+        ];
 
         return sortTableFields(list);
     }, [graphOnChipList, sortTableFields]);

--- a/src/renderer/components/bottom-dock/QueuesTable.tsx
+++ b/src/renderer/components/bottom-dock/QueuesTable.tsx
@@ -5,6 +5,7 @@
 import { IColumnProps, RenderMode, SelectionModes, Table2 } from '@blueprintjs/table';
 import { JSXElementConstructor, ReactElement, useContext, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
+import { type Location, useLocation } from 'react-router-dom';
 import { GraphVertexType } from '../../../data/GraphNames';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { getOperandState } from '../../../data/store/selectors/nodeSelection.selectors';
@@ -12,14 +13,17 @@ import useSelectableGraphVertex from '../../hooks/useSelectableGraphVertex.hook'
 import SelectableOperation from '../SelectableOperation';
 import { columnRenderer } from './SharedTable';
 import useQueuesTableHook, { QueuesTableFields } from './useQueuesTable.hook';
+import type { LocationState } from '../../../data/StateTypes';
 
 /**
  * QueuesTable - temporary component to display queues
  * to be merged with OperationsTable as part of the next refactoring
  */
 function QueuesTable() {
-    const { getActiveGraphOnChip, getOperand } = useContext(GraphOnChipContext);
-    const graphOnChip = getActiveGraphOnChip();
+    const location: Location<LocationState> = useLocation();
+    const { epoch: temporalEpoch, chipId = -1 } = location.state;
+    const { getGraphOnChip, getOperand } = useContext(GraphOnChipContext);
+    const graphOnChip = getGraphOnChip(temporalEpoch, chipId);
     const { queuesTableColumns, sortTableFields, changeSorting, sortDirection, sortingColumn } = useQueuesTableHook();
     const operandState = useSelector(getOperandState);
     const tableFields = useMemo(() => {

--- a/src/renderer/components/bottom-dock/QueuesTable.tsx
+++ b/src/renderer/components/bottom-dock/QueuesTable.tsx
@@ -18,7 +18,7 @@ import useQueuesTableHook, { QueuesTableFields } from './useQueuesTable.hook';
  * to be merged with OperationsTable as part of the next refactoring
  */
 function QueuesTable() {
-    const { getActiveGraphOnChip, getActiveGraphName, getOperand } = useContext(GraphOnChipContext);
+    const { getActiveGraphOnChip, getOperand } = useContext(GraphOnChipContext);
     const graphOnChip = getActiveGraphOnChip();
     const { queuesTableColumns, sortTableFields, changeSorting, sortDirection, sortingColumn } = useQueuesTableHook();
     const operandState = useSelector(getOperandState);
@@ -76,7 +76,7 @@ function QueuesTable() {
                 stringFilter=''
                 value={selected(operandDescriptor.name)}
                 type={operandDescriptor.type}
-                offchip={operandDescriptor.graphName !== getActiveGraphName()}
+                offchip={operandDescriptor.operand.isOffchip}
                 offchipClickHandler={navigateToGraph(operandDescriptor.name)}
             />
         );

--- a/src/renderer/components/bottom-dock/QueuesTable.tsx
+++ b/src/renderer/components/bottom-dock/QueuesTable.tsx
@@ -21,25 +21,28 @@ import type { LocationState } from '../../../data/StateTypes';
  */
 function QueuesTable() {
     const location: Location<LocationState> = useLocation();
-    const { epoch: temporalEpoch, chipId = -1 } = location.state;
+    const { epoch: temporalEpoch, chipId } = location.state;
     const { getGraphOnChip, getOperand } = useContext(GraphOnChipContext);
-    const graphOnChip = getGraphOnChip(temporalEpoch, chipId);
+    const graphOnChipList = getGraphOnChip(temporalEpoch, chipId);
     const { queuesTableColumns, sortTableFields, changeSorting, sortDirection, sortingColumn } = useQueuesTableHook();
     const operandState = useSelector(getOperandState);
     const tableFields = useMemo(() => {
-        if (!graphOnChip) {
+        if (!graphOnChipList) {
             return [];
         }
 
-        const list = [...graphOnChip.queues].map((queue) => {
-            return {
-                name: queue.name,
-                ...queue.details,
-            } as unknown as QueuesTableFields;
-        });
+        const list = graphOnChipList.flatMap(({ graph }) =>
+            [...graph.queues].map(
+                (queue) =>
+                    ({
+                        name: queue.name,
+                        ...queue.details,
+                    }) as unknown as QueuesTableFields,
+            ),
+        );
 
         return sortTableFields(list);
-    }, [graphOnChip, sortTableFields]);
+    }, [graphOnChipList, sortTableFields]);
     const { selected, selectOperand, navigateToGraph } = useSelectableGraphVertex();
 
     const table = useRef<Table2>(null);

--- a/src/renderer/components/cluster-view/ClusterView.tsx
+++ b/src/renderer/components/cluster-view/ClusterView.tsx
@@ -9,11 +9,12 @@ import { Tooltip2 } from '@blueprintjs/popover2';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import { FC, useContext, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { type Location, useLocation } from 'react-router-dom';
 import { ClusterContext } from '../../../data/ClusterContext';
 import getPipeColor from '../../../data/ColorGenerator';
 import GraphOnChip from '../../../data/GraphOnChip';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
-import { GraphRelationship } from '../../../data/StateTypes';
+import { GraphRelationship, type LocationState } from '../../../data/StateTypes';
 import { CLUSTER_ETH_POSITION } from '../../../data/Types';
 import { CLUSTER_NODE_GRID_SIZE } from '../../../data/constants';
 import {
@@ -50,11 +51,13 @@ const renderItem: ItemRenderer<GraphRelationship[]> = (
     );
 };
 const ClusterView: FC = () => {
+    const location: Location<LocationState> = useLocation();
+    const { epoch: temporalEpoch } = location.state;
+
     const { cluster } = useContext(ClusterContext);
-    const { getGraphOnChip, getActiveGraphName, getGraphRelationshipList } = useContext(GraphOnChipContext);
+    const { getGraphOnChip, getGraphRelationshipList } = useContext(GraphOnChipContext);
     const dispatch = useDispatch();
     const graphInformation = getGraphRelationshipList();
-    const selectedGraph = getActiveGraphName();
     const availableTemporalEpochs: GraphRelationship[][] = [];
     const [pciPipes, setPciPipes] = useState<string[]>([]);
 
@@ -66,10 +69,9 @@ const ClusterView: FC = () => {
             availableTemporalEpochs[item.temporalEpoch] = [item];
         }
     });
-    const selectedGraphItem = graphInformation.find((graph) => graph.name === selectedGraph);
 
     const [selectedEpoch, setSelectedEpoch] = useState<GraphRelationship[]>(
-        availableTemporalEpochs[selectedGraphItem?.temporalEpoch || 0] || [],
+        availableTemporalEpochs[temporalEpoch] || [],
     );
 
     /** we want explicit control over the size of chips based on cluster size */

--- a/src/renderer/components/cluster-view/ClusterView.tsx
+++ b/src/renderer/components/cluster-view/ClusterView.tsx
@@ -91,8 +91,8 @@ const ClusterView: FC = () => {
         const pipeList = selectedEpoch
             .map((graph) => {
                 return [
-                    ...(getGraphOnChip(graph.name)?.ethernetPipes.map((pipe) => pipe) || []),
-                    ...(getGraphOnChip(graph.name)?.pciePipes.map((pipe) => {
+                    ...(getGraphOnChip(graph.chipId)?.ethernetPipes.map((pipe) => pipe) || []),
+                    ...(getGraphOnChip(graph.chipId)?.pciePipes.map((pipe) => {
                         pciList.push(pipe.id);
                         return pipe;
                     }) || []),
@@ -287,7 +287,7 @@ const ClusterView: FC = () => {
                     let graphOnChip: GraphOnChip | undefined;
                     let graphName: string | undefined;
                     selectedEpoch.forEach((graph) => {
-                        const chipByGraphName = getGraphOnChip(graph.name);
+                        const chipByGraphName = getGraphOnChip(graph.chipId);
                         if (chipByGraphName?.chipId === clusterChip.id) {
                             graphOnChip = chipByGraphName;
                             graphName = graph.name;

--- a/src/renderer/components/cluster-view/ClusterView.tsx
+++ b/src/renderer/components/cluster-view/ClusterView.tsx
@@ -91,8 +91,8 @@ const ClusterView: FC = () => {
         const pipeList = selectedEpoch
             .map((graph) => {
                 return [
-                    ...(getGraphOnChip(graph.chipId)?.ethernetPipes.map((pipe) => pipe) || []),
-                    ...(getGraphOnChip(graph.chipId)?.pciePipes.map((pipe) => {
+                    ...(getGraphOnChip(graph.temporalEpoch, graph.chipId)?.ethernetPipes.map((pipe) => pipe) || []),
+                    ...(getGraphOnChip(graph.temporalEpoch, graph.chipId)?.pciePipes.map((pipe) => {
                         pciList.push(pipe.id);
                         return pipe;
                     }) || []),
@@ -287,7 +287,7 @@ const ClusterView: FC = () => {
                     let graphOnChip: GraphOnChip | undefined;
                     let graphName: string | undefined;
                     selectedEpoch.forEach((graph) => {
-                        const chipByGraphName = getGraphOnChip(graph.chipId);
+                        const chipByGraphName = getGraphOnChip(graph.temporalEpoch, graph.chipId);
                         if (chipByGraphName?.chipId === clusterChip.id) {
                             graphOnChip = chipByGraphName;
                             graphName = graph.name;

--- a/src/renderer/components/detailed-view-components/DetailedView.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedView.tsx
@@ -29,7 +29,7 @@ const DetailedView: React.FC<DetailedViewProps> = () => {
     const { getActiveGraphOnChip, graphOnChipList } = useContext(GraphOnChipContext);
     const graphOnChip = getActiveGraphOnChip();
     const location: Location<LocationState> = useLocation();
-    const { graphName, epoch: temporalEpoch } = location.state;
+    const { graphName = '', epoch: temporalEpoch } = location.state;
     const detailedViewElement = useRef<HTMLDivElement>(null);
     const zoom = useSelector(getDetailedViewZoom);
 

--- a/src/renderer/components/detailed-view-components/DetailedView.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedView.tsx
@@ -26,14 +26,14 @@ interface DetailedViewProps {}
 
 const DetailedView: React.FC<DetailedViewProps> = () => {
     const dispatch = useDispatch();
-    const { getActiveGraphOnChip, graphOnChipList } = useContext(GraphOnChipContext);
-    const graphOnChip = getActiveGraphOnChip();
     const location: Location<LocationState> = useLocation();
-    const { graphName = '', epoch: temporalEpoch } = location.state;
+    const { graphName = '', epoch: temporalEpoch, chipId = -1 } = location.state;
+    const { getGraphOnChip } = useContext(GraphOnChipContext);
+    const graphOnChip = getGraphOnChip(temporalEpoch, chipId);
     const detailedViewElement = useRef<HTMLDivElement>(null);
     const zoom = useSelector(getDetailedViewZoom);
 
-    const architecture = graphOnChipList[graphName]?.architecture;
+    const architecture = graphOnChip?.architecture;
     const isOpen = useSelector(getDetailedViewOpenState);
     const uid = useSelector(getSelectedDetailsViewUID);
     const node = uid ? graphOnChip?.getNode(uid) : null;

--- a/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
@@ -24,7 +24,7 @@ interface DetailedViewDRAMRendererProps {
 }
 
 const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ node, graphName, temporalEpoch }) => {
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(temporalEpoch, node.chipId);
     const architecture = graphOnChip?.architecture ?? Architecture.NONE;
     const dispatch = useDispatch();
 

--- a/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
@@ -6,10 +6,9 @@ import { Button } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { updateNodeSelection } from 'data/store/slices/nodeSelection.slice';
 import { openDetailedView } from 'data/store/slices/uiState.slice';
-import React, { useContext, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useDispatch } from 'react-redux';
-import { ComputeNode, NOCLink } from '../../../data/GraphOnChip';
-import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
+import GraphOnChip, { ComputeNode, NOCLink } from '../../../data/GraphOnChip';
 import { Architecture, DramBankLinkName, NOC, NOCLinkName } from '../../../data/Types';
 import { filterIterable } from '../../../utils/IterableHelpers';
 import LinkDetails from '../LinkDetails';
@@ -21,10 +20,15 @@ interface DetailedViewDRAMRendererProps {
     node: ComputeNode;
     graphName: string;
     temporalEpoch: number;
+    graphOnChip?: GraphOnChip;
 }
 
-const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ node, graphName, temporalEpoch }) => {
-    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(temporalEpoch, node.chipId);
+const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({
+    node,
+    graphName,
+    temporalEpoch,
+    graphOnChip,
+}) => {
     const architecture = graphOnChip?.architecture ?? Architecture.NONE;
     const dispatch = useDispatch();
 
@@ -76,7 +80,12 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                                                             selected: true,
                                                         }),
                                                     );
-                                                    dispatch(openDetailedView(currentNode.uid));
+                                                    dispatch(
+                                                        openDetailedView({
+                                                            nodeUid: currentNode.uid,
+                                                            chipId: currentNode.chipId,
+                                                        }),
+                                                    );
                                                 }}
                                             />
                                         )}
@@ -161,6 +170,10 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
             </div>
         </>
     );
+};
+
+DetailedViewDRAMRenderer.defaultProps = {
+    graphOnChip: undefined,
 };
 
 export default DetailedViewDRAMRenderer;

--- a/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
@@ -20,7 +20,7 @@ import DetailedViewPipeControls from './DetailedViewPipeControls';
 interface DetailedViewDRAMRendererProps {
     node: ComputeNode;
     graphName: string;
-    temporalEpoch: string;
+    temporalEpoch: number;
 }
 
 const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ node, graphName, temporalEpoch }) => {

--- a/src/renderer/components/detailed-view-components/DetailedViewPipeRenderer.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewPipeRenderer.tsx
@@ -4,11 +4,11 @@
 
 import * as d3 from 'd3';
 import { getHighContrastState } from 'data/store/selectors/uiState.selectors';
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
+import { type Location, useLocation } from 'react-router-dom';
 import { NOCLink, NetworkLink } from '../../../data/GraphOnChip';
-import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import {
     DramBankLinkName,
     EthernetLinkName,
@@ -27,6 +27,7 @@ import {
 } from '../../../data/store/selectors/linkSaturation.selectors';
 import { getSelectedPipesIds } from '../../../data/store/selectors/pipeSelection.selectors';
 import { LinkRenderType, calculateLinkCongestionColor, drawLink, drawPipesDirect } from '../../../utils/DrawingAPI';
+import type { LocationState } from '../../../data/StateTypes';
 
 type DetailedViewPipeRendererProps = {
     links: NetworkLink[];
@@ -35,10 +36,11 @@ type DetailedViewPipeRendererProps = {
 };
 
 const DetailedViewPipeRenderer: React.FC<DetailedViewPipeRendererProps> = ({ links, className, size = 80 }) => {
+    const location: Location<LocationState> = useLocation();
+    const { graphName = '' } = location.state;
     const svgRef = useRef<SVGSVGElement | null>(null);
     const showLinkSaturation = useSelector(getShowLinkSaturation);
     const linkSaturationTreshold = useSelector(getLinkSaturation);
-    const graphName = useContext(GraphOnChipContext).getActiveGraphName();
     const selectedPipeIds = useSelector(getSelectedPipesIds);
     const isHighContrast = useSelector(getHighContrastState);
     const linksData = useSelector(getAllLinksForGraph(graphName));
@@ -126,6 +128,7 @@ const DetailedViewPipeRenderer: React.FC<DetailedViewPipeRendererProps> = ({ lin
 };
 DetailedViewPipeRenderer.defaultProps = {
     className: '',
+    size: 80,
 };
 export default DetailedViewPipeRenderer;
 

--- a/src/renderer/components/folder-picker/LocalFolderSelector.tsx
+++ b/src/renderer/components/folder-picker/LocalFolderSelector.tsx
@@ -49,8 +49,8 @@ const LocalFolderOptions: FC = () => {
                     text={selectedFolderLocationType === 'local' ? getTestName(localFolderPath) : undefined}
                 />
                 <GraphSelector
-                    onSelectGraph={(state) => loadPerfAnalyzerGraph(state)}
-                    onSelectTemporalEpoch={(state) => loadTemporalEpoch(state)}
+                    onSelectGraph={(graphParams) => loadPerfAnalyzerGraph(graphParams)}
+                    onSelectTemporalEpoch={(epochParams) => loadTemporalEpoch(epochParams)}
                     disabled={selectedFolderLocationType === 'remote'}
                 />
                 {error && (

--- a/src/renderer/components/folder-picker/LocalFolderSelector.tsx
+++ b/src/renderer/components/folder-picker/LocalFolderSelector.tsx
@@ -49,8 +49,8 @@ const LocalFolderOptions: FC = () => {
                     text={selectedFolderLocationType === 'local' ? getTestName(localFolderPath) : undefined}
                 />
                 <GraphSelector
-                    onSelectGraph={(graph, temporalEpoch) => loadPerfAnalyzerGraph(graph, temporalEpoch)}
-                    onSelectTemporalEpoch={(temporalEpoch) => loadTemporalEpoch(temporalEpoch)}
+                    onSelectGraph={(state) => loadPerfAnalyzerGraph(state)}
+                    onSelectTemporalEpoch={(state) => loadTemporalEpoch(state)}
                     disabled={selectedFolderLocationType === 'remote'}
                 />
                 {error && (

--- a/src/renderer/components/folder-picker/LocalFolderSelector.tsx
+++ b/src/renderer/components/folder-picker/LocalFolderSelector.tsx
@@ -49,8 +49,8 @@ const LocalFolderOptions: FC = () => {
                     text={selectedFolderLocationType === 'local' ? getTestName(localFolderPath) : undefined}
                 />
                 <GraphSelector
-                    onSelectGraph={(graphParams) => loadPerfAnalyzerGraph(graphParams)}
-                    onSelectTemporalEpoch={(epochParams) => loadTemporalEpoch(epochParams)}
+                    onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
+                    onSelectTemporalEpoch={(temporalEpoch) => loadTemporalEpoch(temporalEpoch)}
                     disabled={selectedFolderLocationType === 'remote'}
                 />
                 {error && (

--- a/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
+++ b/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
@@ -260,8 +260,8 @@ const RemoteSyncConfigurator: FC = () => {
                         />
                     </Tooltip2>
                     <GraphSelector
-                        onSelectGraph={(graphParams) => loadPerfAnalyzerGraph(graphParams)}
-                        onSelectTemporalEpoch={(epochParams) => loadTemporalEpoch(epochParams)}
+                        onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
+                        onSelectTemporalEpoch={(temporalEpoch) => loadTemporalEpoch(temporalEpoch)}
                         disabled={
                             selectedFolderLocationType === 'local' || isSyncingRemoteFolder || isLoadingFolderList
                         }

--- a/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
+++ b/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
@@ -260,8 +260,8 @@ const RemoteSyncConfigurator: FC = () => {
                         />
                     </Tooltip2>
                     <GraphSelector
-                        onSelectGraph={(state) => loadPerfAnalyzerGraph(state)}
-                        onSelectTemporalEpoch={(state) => loadTemporalEpoch(state)}
+                        onSelectGraph={(graphParams) => loadPerfAnalyzerGraph(graphParams)}
+                        onSelectTemporalEpoch={(epochParams) => loadTemporalEpoch(epochParams)}
                         disabled={
                             selectedFolderLocationType === 'local' || isSyncingRemoteFolder || isLoadingFolderList
                         }

--- a/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
+++ b/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
@@ -260,8 +260,8 @@ const RemoteSyncConfigurator: FC = () => {
                         />
                     </Tooltip2>
                     <GraphSelector
-                        onSelectGraph={(graph, temporalEpoch) => loadPerfAnalyzerGraph(graph, temporalEpoch)}
-                        onSelectTemporalEpoch={(temporalEpoch) => loadTemporalEpoch(temporalEpoch)}
+                        onSelectGraph={(state) => loadPerfAnalyzerGraph(state)}
+                        onSelectTemporalEpoch={(state) => loadTemporalEpoch(state)}
                         disabled={
                             selectedFolderLocationType === 'local' || isSyncingRemoteFolder || isLoadingFolderList
                         }

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -21,10 +21,10 @@ interface GraphSelectorProps {
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
     const location: Location<LocationState> = useLocation();
-    const { chipId = -1, epoch } = location.state;
+    const { chipId = -1, epoch = -1 } = location?.state ?? {};
     const { getGraphsListByTemporalEpoch, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
     const temporalEpochs = [...getGraphsListByTemporalEpoch().entries()];
-    const selectedGraph = getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph.name;
+    const selectedGraph = getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph.name ?? '';
 
     return (
         <Popover2

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -10,21 +10,11 @@ import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 
 import './GraphSelector.scss';
 
-export interface LoadGraphParams {
-    epoch: number;
-    graphName: string;
-    chipId: number;
-}
-
-export interface LoadTemporalEpochParams {
-    epoch: number;
-}
-
 interface GraphSelectorProps {
     disabled?: boolean;
     label?: string;
-    onSelectGraph: (graphParams: LoadGraphParams) => void;
-    onSelectTemporalEpoch: (epochParams: LoadTemporalEpochParams) => void;
+    onSelectGraph: (graphName: string) => void;
+    onSelectTemporalEpoch: (temporalEpoch: number) => void;
 }
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
@@ -44,11 +34,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                 <MenuItem
                                     icon={IconNames.SERIES_DERIVED}
                                     key={`temporal-epoch-${temporalEpoch}`}
-                                    onClick={() =>
-                                        onSelectTemporalEpoch({
-                                            epoch: temporalEpoch,
-                                        })
-                                    }
+                                    onClick={() => onSelectTemporalEpoch(temporalEpoch)}
                                     text={`Temporal Epoch ${temporalEpoch}`}
                                     className='graph-selector-temporal-epoch'
                                 />
@@ -56,13 +42,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                     <MenuItem
                                         key={`temporal-epoch-${temporalEpoch}-${graphRelationship.name}`}
                                         text={graphRelationship.name}
-                                        onClick={() =>
-                                            onSelectGraph({
-                                                epoch: temporalEpoch,
-                                                chipId: graphRelationship.chipId,
-                                                graphName: graphRelationship.name,
-                                            })
-                                        }
+                                        onClick={() => onSelectGraph(graphRelationship.name)}
                                         className='graph-selector-graph'
                                     />
                                 ))}

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -9,12 +9,13 @@ import { IconNames } from '@blueprintjs/icons';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 
 import './GraphSelector.scss';
+import type { LocationState } from '../../../data/StateTypes';
 
 interface GraphSelectorProps {
     disabled?: boolean;
     label?: string;
-    onSelectGraph: (graph: string, temporalEpoch: number) => void;
-    onSelectTemporalEpoch: (temporalEpoch: number) => void;
+    onSelectGraph: (state: LocationState) => void;
+    onSelectTemporalEpoch: (state: LocationState) => void;
 }
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
@@ -34,7 +35,11 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                 <MenuItem
                                     icon={IconNames.SERIES_DERIVED}
                                     key={`temporal-epoch-${temporalEpoch}`}
-                                    onClick={() => onSelectTemporalEpoch(temporalEpoch)}
+                                    onClick={() =>
+                                        onSelectTemporalEpoch({
+                                            epoch: temporalEpoch,
+                                        })
+                                    }
                                     text={`Temporal Epoch ${temporalEpoch}`}
                                     className='graph-selector-temporal-epoch'
                                 />
@@ -42,7 +47,13 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                     <MenuItem
                                         key={`temporal-epoch-${temporalEpoch}-${graphRelationship.name}`}
                                         text={graphRelationship.name}
-                                        onClick={() => onSelectGraph(graphRelationship.name, temporalEpoch)}
+                                        onClick={() =>
+                                            onSelectGraph({
+                                                epoch: temporalEpoch,
+                                                chipId: graphRelationship.chipId,
+                                                graphName: graphRelationship.name,
+                                            })
+                                        }
                                         className='graph-selector-graph'
                                     />
                                 ))}

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -9,13 +9,22 @@ import { IconNames } from '@blueprintjs/icons';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 
 import './GraphSelector.scss';
-import type { LocationState } from '../../../data/StateTypes';
+
+export interface LoadGraphParams {
+    epoch: number;
+    graphName: string;
+    chipId: number;
+}
+
+export interface LoadTemporalEpochParams {
+    epoch: number;
+}
 
 interface GraphSelectorProps {
     disabled?: boolean;
     label?: string;
-    onSelectGraph: (state: LocationState) => void;
-    onSelectTemporalEpoch: (state: LocationState) => void;
+    onSelectGraph: (graphParams: LoadGraphParams) => void;
+    onSelectTemporalEpoch: (epochParams: LoadTemporalEpochParams) => void;
 }
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -21,10 +21,16 @@ interface GraphSelectorProps {
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
     const location: Location<LocationState> = useLocation();
-    const { chipId = -1, epoch = -1 } = location?.state ?? {};
+    const { chipId, epoch = -1 } = location?.state ?? {};
     const { getGraphsListByTemporalEpoch, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
     const temporalEpochs = [...getGraphsListByTemporalEpoch().entries()];
-    const selectedGraph = getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph.name ?? '';
+    let selectedItemText = '';
+
+    if (chipId !== undefined) {
+        selectedItemText = getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph.name;
+    } else if (epoch >= 0) {
+        selectedItemText = `Temporal Epoch ${epoch}`;
+    }
 
     return (
         <Popover2
@@ -59,7 +65,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
             placement='right'
         >
             <Button icon={IconNames.GRAPH} disabled={disabled}>
-                {selectedGraph || (label ?? 'Select graph')}
+                {selectedItemText || (label ?? 'Select graph')}
             </Button>
         </Popover2>
     );

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -6,9 +6,11 @@ import { FC, useContext } from 'react';
 import { Popover2 } from '@blueprintjs/popover2';
 import { Button, Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
+import { type Location, useLocation } from 'react-router-dom';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 
 import './GraphSelector.scss';
+import type { LocationState } from '../../../data/StateTypes';
 
 interface GraphSelectorProps {
     disabled?: boolean;
@@ -18,9 +20,11 @@ interface GraphSelectorProps {
 }
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
-    const { getActiveGraphName, getGraphsListByTemporalEpoch } = useContext(GraphOnChipContext);
-    const selectedGraph = getActiveGraphName();
+    const location: Location<LocationState> = useLocation();
+    const { chipId = -1, epoch } = location.state;
+    const { getGraphsListByTemporalEpoch, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
     const temporalEpochs = [...getGraphsListByTemporalEpoch().entries()];
+    const selectedGraph = getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph.name;
 
     return (
         <Popover2

--- a/src/renderer/components/grid-sidebar/CLKBandwidthControls.tsx
+++ b/src/renderer/components/grid-sidebar/CLKBandwidthControls.tsx
@@ -13,6 +13,7 @@ import {
 } from 'data/store/slices/linkSaturation.slice';
 import { FC, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { type Location, useLocation } from 'react-router-dom';
 import { DataIntegrityErrorType } from '../../../data/DataIntegrity';
 import { AICLK_INITIAL_MHZ, DRAM_BANDWIDTH_INITIAL_GBS, PCIE_BANDWIDTH_INITIAL_GBS } from '../../../data/constants';
 import Collapsible from '../Collapsible';
@@ -24,12 +25,14 @@ import {
     getPCIBandwidth,
     getTotalOpsForGraph,
 } from '../../../data/store/selectors/linkSaturation.selectors';
+import type { LocationState } from '../../../data/StateTypes';
 
 interface DRAMBandwidthControlsProps {}
 
 export const CLKBandwidthControls: FC<DRAMBandwidthControlsProps> = () => {
+    const location: Location<LocationState> = useLocation();
+    const { graphName = '' } = location.state;
     const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
-    const graphName = useContext(GraphOnChipContext).getActiveGraphName();
     const dispatch = useDispatch();
     const dramBandwidth = useSelector(getDRAMBandwidth);
     const clkMHz = useSelector(getCLKMhz);

--- a/src/renderer/components/grid-sidebar/CLKBandwidthControls.tsx
+++ b/src/renderer/components/grid-sidebar/CLKBandwidthControls.tsx
@@ -31,8 +31,10 @@ interface DRAMBandwidthControlsProps {}
 
 export const CLKBandwidthControls: FC<DRAMBandwidthControlsProps> = () => {
     const location: Location<LocationState> = useLocation();
-    const { graphName = '' } = location.state;
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
+    const { epoch } = location.state;
+    // TODO: use multiple graphs
+    const { graph: graphOnChip, relationship: { name: graphName } = { name: '' } } =
+        useContext(GraphOnChipContext).getGraphOnChip(epoch)[0] ?? {};
     const dispatch = useDispatch();
     const dramBandwidth = useSelector(getDRAMBandwidth);
     const clkMHz = useSelector(getCLKMhz);

--- a/src/renderer/components/grid-sidebar/CongestionControls.tsx
+++ b/src/renderer/components/grid-sidebar/CongestionControls.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import React, { FC, useContext } from 'react';
+import { FC, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Slider, Switch } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
@@ -17,12 +17,7 @@ import {
     updateShowOperationPerformanceGrid,
 } from '../../../data/store/slices/operationPerf.slice';
 import { clearAllPipes, selectAllPipes } from '../../../data/store/slices/pipeSelection.slice';
-import {
-    clearAllOperationsForGraph,
-    clearAllQueuesforGraph,
-    selectAllOperationsForGraph,
-    selectAllQueuesForGraph,
-} from '../../../data/store/slices/nodeSelection.slice';
+import { selectOperandList } from '../../../data/store/slices/nodeSelection.slice';
 import { getHighContrastState } from '../../../data/store/selectors/uiState.selectors';
 import { calculateOpCongestionColor } from '../../../utils/DrawingAPI';
 
@@ -34,9 +29,14 @@ import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import LinkCongestionControl from './LinkCongestionControl';
 
 export const CongestionControls: FC = () => {
-    const { getActiveGraphOnChip, getActiveGraphName } = useContext(GraphOnChipContext);
+    const { getActiveGraphOnChip } = useContext(GraphOnChipContext);
     const graphOnChip = getActiveGraphOnChip();
-    const graphName = getActiveGraphName();
+
+    const operationsOnGraph = useMemo(
+        () => [...(graphOnChip?.operations ?? [])].map(({ name }) => name),
+        [graphOnChip],
+    );
+    const queuesOnGraph = useMemo(() => [...(graphOnChip?.queues ?? [])].map(({ name }) => name), [graphOnChip]);
 
     const maxBwLimitedFactor = graphOnChip?.details.maxBwLimitedFactor || 10;
     const hasPipes = graphOnChip?.hasPipes || false;
@@ -106,14 +106,28 @@ export const CongestionControls: FC = () => {
                             <Tooltip2 content='Select all operations for active graph'>
                                 <Button
                                     icon={IconNames.CUBE_ADD}
-                                    onClick={() => dispatch(selectAllOperationsForGraph(graphName))}
+                                    onClick={() =>
+                                        dispatch(
+                                            selectOperandList({
+                                                operands: operationsOnGraph,
+                                                selected: true,
+                                            }),
+                                        )
+                                    }
                                 />
                             </Tooltip2>
                             &nbsp;
                             <Tooltip2 content='Deselect all operations for active graph'>
                                 <Button
                                     icon={IconNames.CUBE_REMOVE}
-                                    onClick={() => dispatch(clearAllOperationsForGraph(graphName))}
+                                    onClick={() =>
+                                        dispatch(
+                                            selectOperandList({
+                                                operands: operationsOnGraph,
+                                                selected: false,
+                                            }),
+                                        )
+                                    }
                                 />
                             </Tooltip2>
                         </div>
@@ -122,14 +136,28 @@ export const CongestionControls: FC = () => {
                             <Tooltip2 content='Select all queues for active graph'>
                                 <Button
                                     icon={<QueueIconPlus />}
-                                    onClick={() => dispatch(selectAllQueuesForGraph(graphName))}
+                                    onClick={() =>
+                                        dispatch(
+                                            selectOperandList({
+                                                operands: queuesOnGraph,
+                                                selected: true,
+                                            }),
+                                        )
+                                    }
                                 />
                             </Tooltip2>
                             &nbsp;
                             <Tooltip2 content='Deselect all queues for active graph'>
                                 <Button
                                     icon={<QueueIconMinus />}
-                                    onClick={() => dispatch(clearAllQueuesforGraph(graphName))}
+                                    onClick={() =>
+                                        dispatch(
+                                            selectOperandList({
+                                                operands: queuesOnGraph,
+                                                selected: false,
+                                            }),
+                                        )
+                                    }
                                 />
                             </Tooltip2>
                         </div>

--- a/src/renderer/components/grid-sidebar/CongestionControls.tsx
+++ b/src/renderer/components/grid-sidebar/CongestionControls.tsx
@@ -8,6 +8,7 @@ import { Button, Slider, Switch } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 
 import { IconNames } from '@blueprintjs/icons';
+import { type Location, useLocation } from 'react-router-dom';
 import {
     getOperationPerformanceTreshold,
     getShowOperationPerformanceGrid,
@@ -27,10 +28,13 @@ import QueueIconPlus from '../../../main/assets/QueueIconPlus';
 import QueueIconMinus from '../../../main/assets/QueueIconMinus';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import LinkCongestionControl from './LinkCongestionControl';
+import type { LocationState } from '../../../data/StateTypes';
 
 export const CongestionControls: FC = () => {
-    const { getActiveGraphOnChip } = useContext(GraphOnChipContext);
-    const graphOnChip = getActiveGraphOnChip();
+    const location: Location<LocationState> = useLocation();
+    const { epoch } = location.state;
+    // TODO: use multiple graphs
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch)[0]?.graph;
 
     const operationsOnGraph = useMemo(
         () => [...(graphOnChip?.operations ?? [])].map(({ name }) => name),

--- a/src/renderer/components/grid-sidebar/ModelControls.tsx
+++ b/src/renderer/components/grid-sidebar/ModelControls.tsx
@@ -6,15 +6,20 @@ import { Slider } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { FC, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { type Location, useLocation } from 'react-router-dom';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { MAX_MODEL_RATIO_THRESHOLD, MIN_MODEL_RATIO_THRESHOLD } from '../../../data/constants';
 import { getOperationRatioThreshold } from '../../../data/store/selectors/operationPerf.selectors';
 import { updateOperationRatioThreshold } from '../../../data/store/slices/operationPerf.slice';
 import Collapsible from '../Collapsible';
 import useOperationsTable, { type OpTableFields } from '../bottom-dock/useOperationsTable.hooks';
+import type { LocationState } from '../../../data/StateTypes';
 
 const ModelControls: FC = () => {
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
+    const location: Location<LocationState> = useLocation();
+    const { epoch } = location.state;
+    // TODO: use multiple graphs
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch)[0]?.graph;
     const dispatch = useDispatch();
     const opperationRatioThreshold = useSelector(getOperationRatioThreshold);
     const { getMaxModelEstimateRatio } = useOperationsTable();

--- a/src/renderer/components/node-grid-elements-components/DramModuleBorder.tsx
+++ b/src/renderer/components/node-grid-elements-components/DramModuleBorder.tsx
@@ -10,7 +10,7 @@ import { getDramGroupingStyles } from '../../../utils/DrawingAPI';
 
 interface DramModuleBorderProps {
     node: ComputeNode;
-    temporalEpoch: string;
+    temporalEpoch: number;
 }
 
 /** For a DRAM node, this renders a styling layer when the node's DRAM group is selected */

--- a/src/renderer/components/node-grid-elements-components/DramModuleBorder.tsx
+++ b/src/renderer/components/node-grid-elements-components/DramModuleBorder.tsx
@@ -15,10 +15,10 @@ interface DramModuleBorderProps {
 
 /** For a DRAM node, this renders a styling layer when the node's DRAM group is selected */
 const DramModuleBorder: FC<DramModuleBorderProps> = ({ node, temporalEpoch }) => {
-    const dramSelectionState = useSelector(getDramHighlightState(temporalEpoch, node.uid));
+    const isDramSelected = useSelector(getDramHighlightState(temporalEpoch, node.uid));
     let dramStyles = {};
 
-    if (dramSelectionState) {
+    if (isDramSelected) {
         dramStyles = getDramGroupingStyles(node.dramBorder);
     }
 

--- a/src/renderer/components/node-grid-elements-components/NodeFocusPipeRenderer.tsx
+++ b/src/renderer/components/node-grid-elements-components/NodeFocusPipeRenderer.tsx
@@ -22,7 +22,6 @@ const NodeFocusPipeRenderer: FC<NodeFocusPipeRendererProps> = ({ node }) => {
     svg.selectAll('*').remove();
 
     useEffect(() => {
-        // TODO: debug
         const focusedPipeIds = [focusPipe || ''];
 
         if (focusPipe && node.pipes.filter((pipe) => pipe.id === focusPipe).length > 0) {

--- a/src/renderer/components/node-grid-elements-components/NodeFocusPipeRenderer.tsx
+++ b/src/renderer/components/node-grid-elements-components/NodeFocusPipeRenderer.tsx
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 import * as d3 from 'd3';
-import { FC, useRef } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { ComputeNode } from '../../../data/GraphOnChip';
 import { NOCLinkName } from '../../../data/Types';
@@ -15,28 +15,33 @@ interface NodeFocusPipeRendererProps {
 }
 
 const NodeFocusPipeRenderer: FC<NodeFocusPipeRendererProps> = ({ node }) => {
-    // TODO: note to future self this is working incidently, but once gridview starts being generated later or regenerated this will likely need a useEffect
     const svgRef = useRef<SVGSVGElement | null>(null);
     const svg = d3.select(svgRef.current);
     const focusPipe = useSelector(getFocusPipe);
-    const focusedPipeIds = [focusPipe || ''];
 
     svg.selectAll('*').remove();
-    if (focusPipe && node.pipes.filter((pipe) => pipe.id === focusPipe).length > 0) {
-        drawSelections(svg, NOCLinkName.NOC0_EAST_OUT, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC0_WEST_IN, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC0_SOUTH_OUT, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC0_NORTH_IN, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC0_IN, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC0_OUT, node, focusedPipeIds);
 
-        drawSelections(svg, NOCLinkName.NOC1_NORTH_OUT, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC1_SOUTH_IN, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC1_WEST_OUT, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC1_EAST_IN, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC1_IN, node, focusedPipeIds);
-        drawSelections(svg, NOCLinkName.NOC1_OUT, node, focusedPipeIds);
-    }
+    useEffect(() => {
+        // TODO: debug
+        const focusedPipeIds = [focusPipe || ''];
+
+        if (focusPipe && node.pipes.filter((pipe) => pipe.id === focusPipe).length > 0) {
+            drawSelections(svg, NOCLinkName.NOC0_EAST_OUT, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC0_WEST_IN, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC0_SOUTH_OUT, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC0_NORTH_IN, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC0_IN, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC0_OUT, node, focusedPipeIds);
+
+            drawSelections(svg, NOCLinkName.NOC1_NORTH_OUT, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC1_SOUTH_IN, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC1_WEST_OUT, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC1_EAST_IN, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC1_IN, node, focusedPipeIds);
+            drawSelections(svg, NOCLinkName.NOC1_OUT, node, focusedPipeIds);
+        }
+    }, [focusPipe, node, svg]);
+
     return <svg className='node-focus-svg' ref={svgRef} width={NODE_SIZE} height={NODE_SIZE} />;
 };
 

--- a/src/renderer/components/node-grid-elements-components/NodeLocation.tsx
+++ b/src/renderer/components/node-grid-elements-components/NodeLocation.tsx
@@ -11,7 +11,7 @@ import { formatNodeUID } from '../../../utils/DataUtils';
 const NodeLocation: FC<{ node: ComputeNode }> = ({ node }) => {
     const showNodeLocation = useSelector(getShowNodeUID);
 
-    return showNodeLocation && <div className='node-location'>{formatNodeUID(node.uid)}</div>;
+    return <div className='node-location'>{showNodeLocation ? formatNodeUID(node.uid) : ''}</div>;
 };
 
 export default NodeLocation;

--- a/src/renderer/components/node-grid-elements-components/NodeOperationLabel.tsx
+++ b/src/renderer/components/node-grid-elements-components/NodeOperationLabel.tsx
@@ -3,28 +3,26 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 import { FC } from 'react';
-import { useSelector } from 'react-redux';
-
-import { ComputeNode } from '../../../data/GraphOnChip';
 
 import { getGroupColor } from '../../../data/ColorGenerator';
-import { getShowOperationNames } from '../../../data/store/selectors/uiState.selectors';
 
-const NodeOperationLabel: FC<{ node: ComputeNode }> = ({ node }) => {
-    const showOperationNames = useSelector(getShowOperationNames);
-    // Use the top border to determine if the label should be shown.
-    // It will only show for the items that are the "first" in that selected group.
-    // This may be either vertical or horizontal, so we cover both the top and left borders.
-    const shouldShowLabel = !node.opSiblingNodes?.top && !node.opSiblingNodes?.left;
+const NodeOperationLabel: FC<{ opName: string; shouldRender: boolean }> = ({ opName, shouldRender }) => {
+    let bgColor = 'transparent';
+
+    if (shouldRender && opName !== '') {
+        bgColor = getGroupColor(opName) ?? 'transparent';
+    }
 
     return (
-        node.opName !== '' &&
-        showOperationNames &&
-        shouldShowLabel && (
-            <div className='node-layer op-label' style={{ backgroundColor: getGroupColor(node.opName) }}>
-                {node.opName}
-            </div>
-        )
+        <div
+            className='node-layer op-label'
+            style={{
+                backgroundColor: bgColor,
+                ...((!shouldRender || opName === '') && { display: 'none' }),
+            }}
+        >
+            {opName}
+        </div>
     );
 };
 

--- a/src/renderer/components/node-grid-elements-components/NodePipeRenderer.tsx
+++ b/src/renderer/components/node-grid-elements-components/NodePipeRenderer.tsx
@@ -3,20 +3,13 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 import * as d3 from 'd3';
-import { FC, useContext, useEffect, useRef } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { ComputeNode } from '../../../data/GraphOnChip';
-import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { NOC, NOCLinkName } from '../../../data/Types';
-import {
-    getAllLinksForGraph,
-    getLinkSaturation,
-    getShowLinkSaturation,
-    getShowNOC0,
-    getShowNOC1,
-} from '../../../data/store/selectors/linkSaturation.selectors';
+import { getLinkSaturation, getShowNOC0, getShowNOC1 } from '../../../data/store/selectors/linkSaturation.selectors';
 import { getFocusPipe, getSelectedPipesIds } from '../../../data/store/selectors/pipeSelection.selectors';
-import { getHighContrastState, getShowEmptyLinks } from '../../../data/store/selectors/uiState.selectors';
+import { getShowEmptyLinks } from '../../../data/store/selectors/uiState.selectors';
 import {
     NOC_CONFIGURATION,
     NODE_SIZE,
@@ -25,31 +18,28 @@ import {
     drawNOCRouter,
     drawSelections,
 } from '../../../utils/DrawingAPI';
+import type { LinkState } from '../../../data/StateTypes';
 
 interface NodePipeRendererProps {
     node: ComputeNode;
-    graphName: string;
+    linksData: Record<string, LinkState>;
+    isHighContrast: boolean;
+    showLinkSaturation: boolean;
 }
 
-const NodePipeRenderer: FC<NodePipeRendererProps> = ({ node, graphName }) => {
-    // TODO: note to future self this is working incidently, but once gridview starts being generated later or regenerated this will likely need a useEffect
-    const isHighContrast = useSelector(getHighContrastState);
-    const linksData = useSelector(getAllLinksForGraph(graphName));
-
+const NodePipeRenderer: FC<NodePipeRendererProps> = ({ node, linksData, isHighContrast, showLinkSaturation }) => {
     const focusPipe = useSelector(getFocusPipe);
     const selectedPipeIds = useSelector(getSelectedPipesIds);
 
     const svgRef = useRef<SVGSVGElement | null>(null);
     const svg = d3.select(svgRef.current);
 
-    const showLinkSaturation = useSelector(getShowLinkSaturation);
     const linkSaturationTreshold = useSelector(getLinkSaturation);
 
     const noc0Saturation = useSelector(getShowNOC0);
     const noc1Saturation = useSelector(getShowNOC1);
 
     const showEmptyLinks = useSelector(getShowEmptyLinks);
-
 
     svg.selectAll('*').remove();
 

--- a/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
+++ b/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
@@ -2,72 +2,70 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ComputeNode } from '../../../data/GraphOnChip';
 import { ComputeNodeType } from '../../../data/Types';
-import {
-    getAllLinksForGraph,
-    getLinkSaturation,
-    getShowLinkSaturation,
-} from '../../../data/store/selectors/linkSaturation.selectors';
-import { getHighContrastState } from '../../../data/store/selectors/uiState.selectors';
+import { getLinkSaturation } from '../../../data/store/selectors/linkSaturation.selectors';
 import { calculateLinkCongestionColor, getOffChipCongestionStyles, toRGBA } from '../../../utils/DrawingAPI';
+import type { LinkState } from '../../../data/StateTypes';
 
 interface OffChipNodeLinkCongestionLayerProps {
     node: ComputeNode;
-    graphName: string;
+    linksData: Record<string, LinkState>;
+    showLinkSaturation: boolean;
+    isHighContrast: boolean;
 }
 
 /**
  * This renders a congestion layer for nodes with off chip links (DRAM, Ethernet, PCIe)  for those links
  */
-const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({ node, graphName }) => {
-    const linksData = useSelector(getAllLinksForGraph(graphName));
-    const isHighContrast = useSelector(getHighContrastState);
-    const showLinkSaturation = useSelector(getShowLinkSaturation);
+const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({
+    node,
+    linksData,
+    showLinkSaturation,
+    isHighContrast,
+}) => {
     const linkSaturationTreshold = useSelector(getLinkSaturation);
 
-    if (!showLinkSaturation) {
-        return null;
-    }
+    const saturationValues = useMemo(() => {
+        let offChipLinkIds: string[] = [];
 
-    let congestionStyle = {};
-    const { type } = node;
-    let offChipLinkIds: string[] = [];
+        switch (node.type) {
+            case ComputeNodeType.DRAM:
+                offChipLinkIds =
+                    node.dramChannel?.links.map((link) => {
+                        return link.uid;
+                    }) || [];
+                break;
+            case ComputeNodeType.ETHERNET:
+                offChipLinkIds =
+                    [...node.internalLinks.values()].map((link) => {
+                        return link.uid;
+                    }) || [];
+                break;
 
-    switch (type) {
-        case ComputeNodeType.DRAM:
-            offChipLinkIds =
-                node.dramChannel?.links.map((link) => {
-                    return link.uid;
-                }) || [];
-            break;
-        case ComputeNodeType.ETHERNET:
-            offChipLinkIds =
-                [...node.internalLinks.values()].map((link) => {
-                    return link.uid;
-                }) || [];
-            break;
+            case ComputeNodeType.PCIE:
+                offChipLinkIds =
+                    [...node.internalLinks].map(([link]) => {
+                        return link.uid;
+                    }) || [];
+                break;
+            default:
+                break;
+        }
 
-        case ComputeNodeType.PCIE:
-            offChipLinkIds =
-                [...node.internalLinks].map(([link]) => {
-                    return link.uid;
-                }) || [];
-            break;
-        default:
-            return null;
-    }
+        return offChipLinkIds.map((linkId) => linksData[linkId]?.saturation) || [0];
+    }, [linksData, node]);
 
-    const saturationValues = offChipLinkIds.map((linkId) => linksData[linkId]?.saturation) || [0];
     const saturation = Math.max(...saturationValues) || 0;
-    if (saturation < linkSaturationTreshold) {
-        return null;
+    let congestionStyle = {};
+
+    if (showLinkSaturation && saturation >= linkSaturationTreshold) {
+        const congestionColor = calculateLinkCongestionColor(saturation, 0, isHighContrast);
+        const saturationBg = toRGBA(congestionColor, 0.5);
+        congestionStyle = getOffChipCongestionStyles(saturationBg);
     }
-    const congestionColor = calculateLinkCongestionColor(saturation, 0, isHighContrast);
-    const saturationBg = toRGBA(congestionColor, 0.5);
-    congestionStyle = getOffChipCongestionStyles(saturationBg);
 
     return <div className='off-chip-congestion' style={congestionStyle} />;
 };

--- a/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
+++ b/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
@@ -4,7 +4,6 @@
 
 import { FC } from 'react';
 import { useSelector } from 'react-redux';
-import { type Location, useLocation } from 'react-router-dom';
 import { ComputeNode } from '../../../data/GraphOnChip';
 import { ComputeNodeType } from '../../../data/Types';
 import {
@@ -14,18 +13,16 @@ import {
 } from '../../../data/store/selectors/linkSaturation.selectors';
 import { getHighContrastState } from '../../../data/store/selectors/uiState.selectors';
 import { calculateLinkCongestionColor, getOffChipCongestionStyles, toRGBA } from '../../../utils/DrawingAPI';
-import type { LocationState } from '../../../data/StateTypes';
 
 interface OffChipNodeLinkCongestionLayerProps {
     node: ComputeNode;
+    graphName: string;
 }
 
 /**
  * This renders a congestion layer for nodes with off chip links (DRAM, Ethernet, PCIe)  for those links
  */
-const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({ node }) => {
-    const location: Location<LocationState> = useLocation();
-    const { graphName = '' } = location.state;
+const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({ node, graphName }) => {
     const linksData = useSelector(getAllLinksForGraph(graphName));
     const isHighContrast = useSelector(getHighContrastState);
     const showLinkSaturation = useSelector(getShowLinkSaturation);

--- a/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
+++ b/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
@@ -2,10 +2,10 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import { FC, useContext } from 'react';
+import { FC } from 'react';
 import { useSelector } from 'react-redux';
+import { type Location, useLocation } from 'react-router-dom';
 import { ComputeNode } from '../../../data/GraphOnChip';
-import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { ComputeNodeType } from '../../../data/Types';
 import {
     getAllLinksForGraph,
@@ -14,6 +14,7 @@ import {
 } from '../../../data/store/selectors/linkSaturation.selectors';
 import { getHighContrastState } from '../../../data/store/selectors/uiState.selectors';
 import { calculateLinkCongestionColor, getOffChipCongestionStyles, toRGBA } from '../../../utils/DrawingAPI';
+import type { LocationState } from '../../../data/StateTypes';
 
 interface OffChipNodeLinkCongestionLayerProps {
     node: ComputeNode;
@@ -23,7 +24,8 @@ interface OffChipNodeLinkCongestionLayerProps {
  * This renders a congestion layer for nodes with off chip links (DRAM, Ethernet, PCIe)  for those links
  */
 const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({ node }) => {
-    const graphName = useContext(GraphOnChipContext).getActiveGraphName();
+    const location: Location<LocationState> = useLocation();
+    const { graphName = '' } = location.state;
     const linksData = useSelector(getAllLinksForGraph(graphName));
     const isHighContrast = useSelector(getHighContrastState);
     const showLinkSaturation = useSelector(getShowLinkSaturation);

--- a/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
+++ b/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
@@ -28,7 +28,7 @@ const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = 
 }) => {
     const linkSaturationTreshold = useSelector(getLinkSaturation);
 
-    const saturationValues = useMemo(() => {
+    const saturation = useMemo(() => {
         let offChipLinkIds: string[] = [];
 
         switch (node.type) {
@@ -55,10 +55,11 @@ const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = 
                 break;
         }
 
-        return offChipLinkIds.map((linkId) => linksData[linkId]?.saturation) || [0];
+        const saturationValues = offChipLinkIds.map((linkId) => linksData[linkId]?.saturation) || [0];
+
+        return Math.max(...saturationValues) || 0;
     }, [linksData, node]);
 
-    const saturation = Math.max(...saturationValues) || 0;
     let congestionStyle = {};
 
     if (showLinkSaturation && saturation >= linkSaturationTreshold) {

--- a/src/renderer/components/node-grid-elements-components/OperationCongestionLayer.tsx
+++ b/src/renderer/components/node-grid-elements-components/OperationCongestionLayer.tsx
@@ -6,37 +6,31 @@ import { FC } from 'react';
 import { useSelector } from 'react-redux';
 import { ComputeNode } from '../../../data/GraphOnChip';
 import { ComputeNodeType } from '../../../data/Types';
-import {
-    getOperationPerformanceTreshold,
-    getShowOperationPerformanceGrid,
-} from '../../../data/store/selectors/operationPerf.selectors';
-import { getHighContrastState } from '../../../data/store/selectors/uiState.selectors';
+import { getOperationPerformanceTreshold } from '../../../data/store/selectors/operationPerf.selectors';
 import { calculateOpCongestionColor, toRGBA } from '../../../utils/DrawingAPI';
 
-const OperationCongestionLayer: FC<{ node: ComputeNode }> = ({ node }) => {
-    const render = useSelector(getShowOperationPerformanceGrid);
+const OperationCongestionLayer: FC<{ node: ComputeNode; isHighContrast: boolean; shouldRender: boolean }> = ({
+    node,
+    isHighContrast,
+    shouldRender,
+}) => {
     const threshold = useSelector(getOperationPerformanceTreshold);
-    const isHighContrast: boolean = useSelector(getHighContrastState);
-
-    if (!render) {
-        return null;
-    }
-
-    if (node.type !== ComputeNodeType.CORE || node.opName === '') {
-        return null;
-    }
 
     const opFactor = node.perfAnalyzerResults?.bw_limited_factor || 1;
+    const isCoreNode = node.type === ComputeNodeType.CORE && node.opName !== '';
+    let congestionColor = 'transparent';
+    let opFactorLabel = '';
 
-    if (opFactor > threshold) {
-        const congestionColor = toRGBA(calculateOpCongestionColor(opFactor, 0, isHighContrast), 0.5);
-        return (
-            <div className='operation-congestion' style={{ backgroundColor: congestionColor }}>
-                {opFactor}
-            </div>
-        );
+    if (shouldRender && isCoreNode && opFactor > threshold) {
+        congestionColor = toRGBA(calculateOpCongestionColor(opFactor, 0, isHighContrast), 0.5);
+        opFactorLabel = opFactor.toString();
     }
-    return <div className='operation-congestion' />;
+
+    return (
+        <div className='operation-congestion' style={{ backgroundColor: congestionColor }}>
+            {opFactorLabel}
+        </div>
+    );
 };
 
 export default OperationCongestionLayer;

--- a/src/renderer/components/node-grid-elements-components/QueueHighlightRenderer.tsx
+++ b/src/renderer/components/node-grid-elements-components/QueueHighlightRenderer.tsx
@@ -2,31 +2,30 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getGroupColor } from '../../../data/ColorGenerator';
 import { ComputeNode } from '../../../data/GraphOnChip';
 import { getOperandStateList } from '../../../data/store/selectors/nodeSelection.selectors';
 
 const QueueHighlightRenderer: FC<{ node: ComputeNode }> = ({ node }) => {
-    const selected = useSelector(getOperandStateList)(node.queueList.map((queue) => queue.name));
-
-    return (
-        <div className='queue-highlighter-content'>
-            {selected.map((queue, index) => {
-                if (queue.selected) {
-                    return (
-                        <div
-                            key={node.queueList[index].name}
-                            className='queue-highlighter'
-                            style={{ backgroundColor: getGroupColor(node.queueList[index].name) }}
-                        />
-                    );
-                }
-                return null;
-            })}
-        </div>
+    const queueNameList = useMemo(() => node.queueList.map((queue) => queue.name), [node]);
+    const selected = useSelector(getOperandStateList)(queueNameList);
+    const selectedNodes = useMemo(
+        () =>
+            selected.map((queue, index) => (
+                <div
+                    key={node.queueList[index].name}
+                    className='queue-highlighter'
+                    style={{
+                        backgroundColor: queue.selected ? getGroupColor(node.queueList[index].name) : 'transparent',
+                    }}
+                />
+            )),
+        [node.queueList, selected],
     );
+
+    return <div className='queue-highlighter-content'>{selectedNodes}</div>;
 };
 
 export default QueueHighlightRenderer;

--- a/src/renderer/components/node-grid-elements-components/QueueHighlightRenderer.tsx
+++ b/src/renderer/components/node-grid-elements-components/QueueHighlightRenderer.tsx
@@ -9,7 +9,7 @@ import { ComputeNode } from '../../../data/GraphOnChip';
 import { getOperandStateList } from '../../../data/store/selectors/nodeSelection.selectors';
 
 const QueueHighlightRenderer: FC<{ node: ComputeNode }> = ({ node }) => {
-    const selected = useSelector(getOperandStateList(node.queueList.map((queue) => queue.name)));
+    const selected = useSelector(getOperandStateList)(node.queueList.map((queue) => queue.name));
 
     return (
         <div className='queue-highlighter-content'>

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -353,36 +353,25 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, graphName }: ComputeNo
 const ComputeNodesPropertiesTab = () => {
     const location: Location<LocationState> = useLocation();
     const { epoch: temporalEpoch, graphName } = location.state;
-    const { graphOnChipList } = useContext(GraphOnChipContext);
+    const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(temporalEpoch);
     const orderedNodeSelection = useSelector(getOrderedNodeList(temporalEpoch));
     const selectedNodes = useMemo(() => {
         const selectedNodesList = orderedNodeSelection
             .map((nodeState) => {
-                try {
-                    return {
-                        node: graphOnChipList[nodeState.graphName].getNode(nodeState.id),
-                        graphName: nodeState.graphName,
-                    };
-                } catch (err) {
-                    console.error(err);
-                }
+                const graphOnChip = graphList.find(({ graph: { chipId } }) => chipId === nodeState.chipId);
 
-                return undefined;
+                return graphOnChip?.graphOnChip.getNode(nodeState.id);
             })
-            .filter((node) => node) as { node: ComputeNode; graphName: string }[];
-
-        if (graphName) {
-            return selectedNodesList.filter((node) => node.graphName === graphName);
-        }
+            .filter((node) => node) as ComputeNode[];
 
         return selectedNodesList;
-    }, [graphOnChipList, orderedNodeSelection, graphName]);
+    }, [graphList, orderedNodeSelection]);
 
     return (
         <div className={`properties-container ${selectedNodes.length > 0 ? '' : 'empty'}`}>
             <div className='properties-list'>
                 <div className='properties-panel-nodes'>
-                    {selectedNodes.map(({ node }) => (
+                    {selectedNodes.map((node) => (
                         <ComputeNodePropertiesCard
                             key={node?.uid}
                             node={node}

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -31,7 +31,7 @@ import type { LocationState } from '../../../data/StateTypes';
 
 interface ComputeNodeProps {
     node: ComputeNode;
-    temporalEpoch: string;
+    temporalEpoch: number;
     graphName: string;
 }
 

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -358,13 +358,21 @@ const ComputeNodesPropertiesTab = ({
 }) => {
     const orderedNodeSelection = useSelector(getOrderedSelectedNodeList(epoch));
     const selectedNodes = useMemo(() => {
-        const selectedNodesList = orderedNodeSelection
-            .map((nodeState) => {
-                const graphOnChip = graphs.find(({ relationship }) => relationship.chipId === nodeState.chipId);
+        const selectedNodesList = orderedNodeSelection.reduce(
+            (graphList, nodeState) => {
+                const graphOnChip = graphs.find(({ graph }) => graph.chipId === nodeState.chipId);
 
-                return { node: graphOnChip?.graph.getNode(nodeState.id), graphName: graphOnChip?.relationship.name };
-            })
-            .filter((node) => node) as { node: ComputeNode; graphName: string }[];
+                if (graphOnChip) {
+                    graphList.push({
+                        node: graphOnChip?.graph.getNode(nodeState.id),
+                        graphName: graphOnChip?.relationship.name,
+                    });
+                }
+
+                return graphList;
+            },
+            [] as { node: ComputeNode; graphName: string }[],
+        );
 
         return selectedNodesList;
     }, [graphs, orderedNodeSelection]);

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -7,7 +7,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { updateNodeSelection } from 'data/store/slices/nodeSelection.slice';
 import { updatePipeSelection } from 'data/store/slices/pipeSelection.slice';
-import { openDetailedView } from 'data/store/slices/uiState.slice';
+import { closeDetailedView, openDetailedView } from 'data/store/slices/uiState.slice';
 import React, { Fragment, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { JSX } from 'react/jsx-runtime';
@@ -149,6 +149,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, graphName }: ComputeNo
                         icon={IconNames.CROSS}
                         onClick={() => {
                             dispatch(updateNodeSelection({ temporalEpoch, id: node.uid, selected: false }));
+                            dispatch(closeDetailedView());
                         }}
                     />
                 </Tooltip2>
@@ -301,7 +302,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, graphName }: ComputeNo
                         icon={IconNames.PROPERTIES}
                         disabled={node.uid === selectedDetailsViewUID && isDetailsViewOpen}
                         onClick={() => {
-                            dispatch(openDetailedView(node.uid));
+                            dispatch(openDetailedView({ nodeUid: node.uid, chipId: node.chipId }));
                         }}
                     >
                         Detailed View

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -358,9 +358,9 @@ const ComputeNodesPropertiesTab = () => {
     const selectedNodes = useMemo(() => {
         const selectedNodesList = orderedNodeSelection
             .map((nodeState) => {
-                const graphOnChip = graphList.find(({ graph: { chipId } }) => chipId === nodeState.chipId);
+                const graphOnChip = graphList[nodeState.chipId]?.graphOnChip;
 
-                return graphOnChip?.graphOnChip.getNode(nodeState.id);
+                return graphOnChip?.getNode(nodeState.id);
             })
             .filter((node) => node) as ComputeNode[];
 

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -11,7 +11,6 @@ import { openDetailedView } from 'data/store/slices/uiState.slice';
 import React, { Fragment, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { JSX } from 'react/jsx-runtime';
-import { type Location, useLocation } from 'react-router-dom';
 import { GraphVertexType } from '../../../data/GraphNames';
 import { ComputeNode, NOCLink, PipeSegment } from '../../../data/GraphOnChip';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
@@ -27,7 +26,6 @@ import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 import LinkDetails from '../LinkDetails';
 import SelectableOperation from '../SelectableOperation';
 import SelectablePipe from '../SelectablePipe';
-import type { LocationState } from '../../../data/StateTypes';
 
 interface ComputeNodeProps {
     node: ComputeNode;
@@ -350,11 +348,9 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, graphName }: ComputeNo
     );
 };
 
-const ComputeNodesPropertiesTab = () => {
-    const location: Location<LocationState> = useLocation();
-    const { epoch: temporalEpoch, graphName = '' } = location.state;
-    const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(temporalEpoch);
-    const orderedNodeSelection = useSelector(getOrderedSelectedNodeList(temporalEpoch));
+const ComputeNodesPropertiesTab = ({ epoch, graphName }: { epoch: number; graphName: string }) => {
+    const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(epoch);
+    const orderedNodeSelection = useSelector(getOrderedSelectedNodeList(epoch));
     const selectedNodes = useMemo(() => {
         const selectedNodesList = orderedNodeSelection
             .map((nodeState) => {
@@ -375,7 +371,7 @@ const ComputeNodesPropertiesTab = () => {
                         <ComputeNodePropertiesCard
                             key={node?.uid}
                             node={node}
-                            temporalEpoch={temporalEpoch}
+                            temporalEpoch={epoch}
                             graphName={graphName}
                         />
                     ))}

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -17,7 +17,7 @@ import { ComputeNode, NOCLink, PipeSegment } from '../../../data/GraphOnChip';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { OperandDirection } from '../../../data/OpPerfDetails';
 import { ComputeNodeType, NOCLinkName } from '../../../data/Types';
-import { getOrderedNodeList } from '../../../data/store/selectors/nodeSelection.selectors';
+import { getOrderedSelectedNodeList } from '../../../data/store/selectors/nodeSelection.selectors';
 import { getDetailedViewOpenState, getSelectedDetailsViewUID } from '../../../data/store/selectors/uiState.selectors';
 import { calculateSlowestOperand, formatNodeUID } from '../../../utils/DataUtils';
 import useSelectableGraphVertex from '../../hooks/useSelectableGraphVertex.hook';
@@ -354,7 +354,7 @@ const ComputeNodesPropertiesTab = () => {
     const location: Location<LocationState> = useLocation();
     const { epoch: temporalEpoch, graphName } = location.state;
     const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(temporalEpoch);
-    const orderedNodeSelection = useSelector(getOrderedNodeList(temporalEpoch));
+    const orderedNodeSelection = useSelector(getOrderedSelectedNodeList(temporalEpoch));
     const selectedNodes = useMemo(() => {
         const selectedNodesList = orderedNodeSelection
             .map((nodeState) => {

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -352,7 +352,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, graphName }: ComputeNo
 
 const ComputeNodesPropertiesTab = () => {
     const location: Location<LocationState> = useLocation();
-    const { epoch: temporalEpoch, graphName } = location.state;
+    const { epoch: temporalEpoch, graphName = '' } = location.state;
     const graphList = useContext(GraphOnChipContext).getGraphOnChipListForTemporalEpoch(temporalEpoch);
     const orderedNodeSelection = useSelector(getOrderedSelectedNodeList(temporalEpoch));
     const selectedNodes = useMemo(() => {

--- a/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
@@ -15,13 +15,28 @@ import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 import type GraphOnChip from '../../../data/GraphOnChip';
 import type { GraphRelationship } from '../../../data/StateTypes';
+import type { Operation } from '../../../data/GraphTypes';
 
 const OperationsPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; relationship: GraphRelationship }[] }) => {
     const dispatch = useDispatch();
 
     const [filterQuery, setFilterQuery] = useState<string>('');
-    // TODO: filter dupes
-    const operationsList = useMemo(() => [...new Set(graphs.flatMap(({ graph }) => [...graph.operations]))], [graphs]);
+    const operationsList = useMemo(
+        () => [
+            ...graphs
+                .reduce((opMap, { graph }) => {
+                    [...graph.operations].forEach((op) => {
+                        if (!opMap.has(op.name)) {
+                            opMap.set(op.name, op);
+                        }
+                    });
+
+                    return opMap;
+                }, new Map<string, Operation>())
+                .values(),
+        ],
+        [graphs],
+    );
     const [allOpen, setAllOpen] = useState(true);
 
     const updateFilteredOperationSelection = (selected: boolean) => {

--- a/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
@@ -6,7 +6,7 @@ import { Button, PopoverPosition } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { selectOperandList } from 'data/store/slices/nodeSelection.slice';
-import React, { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { Operation } from '../../../data/GraphTypes';
@@ -16,10 +16,10 @@ import GraphVertexDetails from '../GraphVertexDetails';
 import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 
-const OperationsPropertiesTab = (): React.ReactElement => {
+const OperationsPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: number }) => {
     const dispatch = useDispatch();
-    const { getActiveGraphOnChip } = useContext(GraphOnChipContext);
-    const graphOnChip = getActiveGraphOnChip();
+    const { getGraphOnChip } = useContext(GraphOnChipContext);
+    const graphOnChip = getGraphOnChip(epoch, chipId);
 
     const [filterQuery, setFilterQuery] = useState<string>('');
     const operationsList = useMemo(() => (graphOnChip ? [...graphOnChip.operations] : []), [graphOnChip]);

--- a/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
@@ -20,6 +20,7 @@ const OperationsPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; rel
     const dispatch = useDispatch();
 
     const [filterQuery, setFilterQuery] = useState<string>('');
+    // TODO: filter dupes
     const operationsList = useMemo(() => [...new Set(graphs.flatMap(({ graph }) => [...graph.operations]))], [graphs]);
     const [allOpen, setAllOpen] = useState(true);
 

--- a/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
@@ -6,23 +6,21 @@ import { Button, PopoverPosition } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import { selectOperandList } from 'data/store/slices/nodeSelection.slice';
-import { useContext, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
-import { Operation } from '../../../data/GraphTypes';
 import Collapsible from '../Collapsible';
 import FilterableComponent from '../FilterableComponent';
 import GraphVertexDetails from '../GraphVertexDetails';
 import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
+import type GraphOnChip from '../../../data/GraphOnChip';
+import type { GraphRelationship } from '../../../data/StateTypes';
 
-const OperationsPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: number }) => {
+const OperationsPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; relationship: GraphRelationship }[] }) => {
     const dispatch = useDispatch();
-    const { getGraphOnChip } = useContext(GraphOnChipContext);
-    const graphOnChip = getGraphOnChip(epoch, chipId);
 
     const [filterQuery, setFilterQuery] = useState<string>('');
-    const operationsList = useMemo(() => (graphOnChip ? [...graphOnChip.operations] : []), [graphOnChip]);
+    const operationsList = useMemo(() => [...new Set(graphs.flatMap(({ graph }) => [...graph.operations]))], [graphs]);
     const [allOpen, setAllOpen] = useState(true);
 
     const updateFilteredOperationSelection = (selected: boolean) => {
@@ -71,10 +69,11 @@ const OperationsPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: num
                 <Button onClick={() => setAllOpen(false)} minimal rightIcon={IconNames.DOUBLE_CHEVRON_UP} />
             </div>
             <div className='properties-list'>
-                {operationsList.map((operation: Operation) => {
+                {operationsList.map((operation, index) => {
                     return (
                         <FilterableComponent
-                            key={operation.name}
+                            // eslint-disable-next-line react/no-array-index-key
+                            key={`${index}-${operation.name}`}
                             filterableString={operation.name}
                             filterQuery={filterQuery}
                             component={

--- a/src/renderer/components/properties-panel/PipesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/PipesPropertiesTab.tsx
@@ -14,9 +14,9 @@ import FilterableComponent from '../FilterableComponent';
 import SearchField from '../SearchField';
 import SelectablePipe from '../SelectablePipe';
 
-const PipesPropertiesTab = () => {
+const PipesPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: number }) => {
     const dispatch = useDispatch();
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch, chipId);
 
     const [pipeFilter, setPipeFilter] = useState<string>('');
 

--- a/src/renderer/components/properties-panel/PipesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/PipesPropertiesTab.tsx
@@ -17,6 +17,7 @@ import type { GraphRelationship } from '../../../data/StateTypes';
 const PipesPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; relationship: GraphRelationship }[] }) => {
     const dispatch = useDispatch();
     const [pipeFilter, setPipeFilter] = useState<string>('');
+    // TODO: filter dupes
     const pipeSegments = useMemo(() => graphs.flatMap(({ graph }) => graph.allUniquePipes), [graphs]);
 
     const selectFilteredPipes = () => {

--- a/src/renderer/components/properties-panel/PropertiesPanel.tsx
+++ b/src/renderer/components/properties-panel/PropertiesPanel.tsx
@@ -18,50 +18,45 @@ import type { LocationState } from '../../../data/StateTypes';
 
 export default function PropertiesPanel() {
     const location: Location<LocationState> = useLocation();
-    const { chipId = -1, epoch, graphName = '' } = location.state;
+    const { chipId, epoch } = location.state;
     const [selectedTab, setSelectedTab] = useState<TabId>('tab-nodes');
-    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch, chipId);
+    const graphOnChipList = useContext(GraphOnChipContext).getGraphOnChip(epoch, chipId);
+
     return (
         <div className='properties-panel'>
             <Tabs id='my-tabs' selectedTabId={selectedTab} onChange={setSelectedTab} className='properties-tabs'>
                 <Tab
                     id='tab-nodes'
                     title='Nodes'
-                    panel={<ComputeNodesPropertiesTab epoch={epoch} graphName={graphName} />}
+                    panel={<ComputeNodesPropertiesTab graphs={graphOnChipList} epoch={epoch} />}
                 />
-                {graphOnChip?.hasPipes && (
-                    <Tab
-                        id='tab-pipes'
-                        title={
-                            <span>
-                                Pipes <Icon icon={IconNames.FILTER} />
-                            </span>
-                        }
-                        panel={<PipesPropertiesTab epoch={epoch} chipId={chipId} />}
-                    />
-                )}
-                {graphOnChip?.hasOperations && (
-                    <Tab
-                        id='tab-ops'
-                        title={
-                            <span>
-                                Operations <Icon icon={IconNames.CUBE} />
-                            </span>
-                        }
-                        panel={<OperationsPropertiesTab chipId={chipId} epoch={epoch} />}
-                    />
-                )}
-                {graphOnChip?.hasQueues && (
-                    <Tab
-                        id='tab-queues'
-                        title={
-                            <span>
-                                Queues <QueueIcon />{' '}
-                            </span>
-                        }
-                        panel={<QueuesPropertiesTab chipId={chipId} epoch={epoch} />}
-                    />
-                )}
+                <Tab
+                    id='tab-pipes'
+                    title={
+                        <span>
+                            Pipes <Icon icon={IconNames.FILTER} />
+                        </span>
+                    }
+                    panel={<PipesPropertiesTab graphs={graphOnChipList} />}
+                />
+                <Tab
+                    id='tab-ops'
+                    title={
+                        <span>
+                            Operations <Icon icon={IconNames.CUBE} />
+                        </span>
+                    }
+                    panel={<OperationsPropertiesTab graphs={graphOnChipList} />}
+                />
+                <Tab
+                    id='tab-queues'
+                    title={
+                        <span>
+                            Queues <QueueIcon />{' '}
+                        </span>
+                    }
+                    panel={<QueuesPropertiesTab graphs={graphOnChipList} />}
+                />
             </Tabs>
             <div className='panel-overlay' />
         </div>

--- a/src/renderer/components/properties-panel/PropertiesPanel.tsx
+++ b/src/renderer/components/properties-panel/PropertiesPanel.tsx
@@ -5,6 +5,7 @@
 import { Icon, Tab, TabId, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { useContext, useState } from 'react';
+import { type Location, useLocation } from 'react-router-dom';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import QueueIcon from '../../../main/assets/QueueIcon';
 import ComputeNodesPropertiesTab from './ComputeNodesPropertiesTab';
@@ -13,14 +14,21 @@ import PipesPropertiesTab from './PipesPropertiesTab';
 import QueuesPropertiesTab from './QueuesPropertiesTab';
 
 import './PropertiesPanel.scss';
+import type { LocationState } from '../../../data/StateTypes';
 
 export default function PropertiesPanel() {
+    const location: Location<LocationState> = useLocation();
+    const { chipId = -1, epoch, graphName = '' } = location.state;
     const [selectedTab, setSelectedTab] = useState<TabId>('tab-nodes');
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
+    const graphOnChip = useContext(GraphOnChipContext).getGraphOnChip(epoch, chipId);
     return (
         <div className='properties-panel'>
             <Tabs id='my-tabs' selectedTabId={selectedTab} onChange={setSelectedTab} className='properties-tabs'>
-                <Tab id='tab-nodes' title='Nodes' panel={<ComputeNodesPropertiesTab />} />
+                <Tab
+                    id='tab-nodes'
+                    title='Nodes'
+                    panel={<ComputeNodesPropertiesTab epoch={epoch} graphName={graphName} />}
+                />
                 {graphOnChip?.hasPipes && (
                     <Tab
                         id='tab-pipes'
@@ -29,7 +37,7 @@ export default function PropertiesPanel() {
                                 Pipes <Icon icon={IconNames.FILTER} />
                             </span>
                         }
-                        panel={<PipesPropertiesTab />}
+                        panel={<PipesPropertiesTab epoch={epoch} chipId={chipId} />}
                     />
                 )}
                 {graphOnChip?.hasOperations && (
@@ -40,7 +48,7 @@ export default function PropertiesPanel() {
                                 Operations <Icon icon={IconNames.CUBE} />
                             </span>
                         }
-                        panel={<OperationsPropertiesTab />}
+                        panel={<OperationsPropertiesTab chipId={chipId} epoch={epoch} />}
                     />
                 )}
                 {graphOnChip?.hasQueues && (
@@ -51,11 +59,11 @@ export default function PropertiesPanel() {
                                 Queues <QueueIcon />{' '}
                             </span>
                         }
-                        panel={<QueuesPropertiesTab />}
+                        panel={<QueuesPropertiesTab chipId={chipId} epoch={epoch} />}
                     />
                 )}
             </Tabs>
-            <div className='panel-overlay'></div>
+            <div className='panel-overlay' />
         </div>
     );
 }

--- a/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
@@ -17,13 +17,28 @@ import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 import type GraphOnChip from '../../../data/GraphOnChip';
 import type { GraphRelationship } from '../../../data/StateTypes';
+import type { Queue } from '../../../data/GraphTypes';
 
 const QueuesPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; relationship: GraphRelationship }[] }) => {
     const dispatch = useDispatch();
     const [allOpen, setAllOpen] = useState(true);
     const [filterQuery, setFilterQuery] = useState<string>('');
-    // TODO: filter dupes
-    const queuesList = useMemo(() => [...new Set(graphs.flatMap(({ graph }) => [...graph.queues]))], [graphs]);
+    const queuesList = useMemo(
+        () => [
+            ...graphs
+                .reduce((queueMap, { graph }) => {
+                    [...graph.queues].forEach((queue) => {
+                        if (!queueMap.has(queue.name)) {
+                            queueMap.set(queue.name, queue);
+                        }
+                    });
+
+                    return queueMap;
+                }, new Map<string, Queue>())
+                .values(),
+        ],
+        [graphs],
+    );
 
     const updateFilteredQueueSelection = (selected: boolean) => {
         if (!queuesList.length) {

--- a/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
@@ -22,6 +22,7 @@ const QueuesPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; relatio
     const dispatch = useDispatch();
     const [allOpen, setAllOpen] = useState(true);
     const [filterQuery, setFilterQuery] = useState<string>('');
+    // TODO: filter dupes
     const queuesList = useMemo(() => [...new Set(graphs.flatMap(({ graph }) => [...graph.queues]))], [graphs]);
 
     const updateFilteredQueueSelection = (selected: boolean) => {

--- a/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
@@ -5,9 +5,8 @@
 import { Button, PopoverPosition } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import { useContext, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { selectOperandList } from '../../../data/store/slices/nodeSelection.slice';
 import QueueIconMinus from '../../../main/assets/QueueIconMinus';
 import QueueIconPlus from '../../../main/assets/QueueIconPlus';
@@ -16,15 +15,14 @@ import FilterableComponent from '../FilterableComponent';
 import GraphVertexDetails from '../GraphVertexDetails';
 import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
+import type GraphOnChip from '../../../data/GraphOnChip';
+import type { GraphRelationship } from '../../../data/StateTypes';
 
-const QueuesPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: number }) => {
+const QueuesPropertiesTab = ({ graphs }: { graphs: { graph: GraphOnChip; relationship: GraphRelationship }[] }) => {
     const dispatch = useDispatch();
-    const { getGraphOnChip } = useContext(GraphOnChipContext);
-    const graphOnChip = getGraphOnChip(epoch, chipId);
-
     const [allOpen, setAllOpen] = useState(true);
     const [filterQuery, setFilterQuery] = useState<string>('');
-    const queuesList = useMemo(() => (graphOnChip ? [...graphOnChip.queues] : []), [graphOnChip]);
+    const queuesList = useMemo(() => [...new Set(graphs.flatMap(({ graph }) => [...graph.queues]))], [graphs]);
 
     const updateFilteredQueueSelection = (selected: boolean) => {
         if (!queuesList.length) {
@@ -69,14 +67,16 @@ const QueuesPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: number 
             </div>
 
             <div className='properties-list'>
-                {queuesList.map((queue) => (
+                {queuesList.map((queue, index) => (
                     <FilterableComponent
-                        key={queue.name}
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={`${index}-${queue.name}`}
                         filterableString={queue.name}
                         filterQuery={filterQuery}
                         component={
                             <Collapsible
-                                key={queue.name}
+                                // eslint-disable-next-line react/no-array-index-key
+                                key={`collapsible-${index}-${queue.name}`}
                                 label={
                                     <GraphVertexDetailsSelectables
                                         operand={queue}

--- a/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
@@ -5,7 +5,7 @@
 import { Button, PopoverPosition } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
-import React, { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import { selectOperandList } from '../../../data/store/slices/nodeSelection.slice';
@@ -17,10 +17,10 @@ import GraphVertexDetails from '../GraphVertexDetails';
 import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 
-const QueuesPropertiesTab = (): React.ReactElement => {
+const QueuesPropertiesTab = ({ chipId, epoch }: { chipId: number; epoch: number }) => {
     const dispatch = useDispatch();
-    const { getActiveGraphOnChip } = useContext(GraphOnChipContext);
-    const graphOnChip = getActiveGraphOnChip();
+    const { getGraphOnChip } = useContext(GraphOnChipContext);
+    const graphOnChip = getGraphOnChip(epoch, chipId);
 
     const [allOpen, setAllOpen] = useState(true);
     const [filterQuery, setFilterQuery] = useState<string>('');

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -120,7 +120,7 @@ const usePerfAnalyzerFileLoader = () => {
                 }
 
                 nodesDataPerTemporalEpoch[graph.temporalEpoch].push(
-                    ...mapIterable(graphOnChip.nodes, (node) => node.generateInitialState(graph.name)),
+                    ...mapIterable(graphOnChip.nodes, (node) => node.generateInitialState()),
                 );
 
                 times.push({

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -41,8 +41,7 @@ const usePerfAnalyzerFileLoader = () => {
     const [error, setError] = useState<string | null>(null);
     const logging = useLogging();
     const { setCluster } = useContext<ClusterModel>(ClusterContext);
-    const { setActiveGraph, loadGraphOnChips, resetGraphOnChipState, getGraphRelationshipByGraphName } =
-        useContext(GraphOnChipContext);
+    const { loadGraphOnChips, resetGraphOnChipState, getGraphRelationshipByGraphName } = useContext(GraphOnChipContext);
     const navigate = useNavigate();
     const location: Location<LocationState> = useLocation();
     const logger = useLogging();
@@ -166,7 +165,6 @@ const usePerfAnalyzerFileLoader = () => {
             }
 
             dispatch(closeDetailedView());
-            setActiveGraph(graphName);
 
             navigate('/render', {
                 state: {

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -34,7 +34,6 @@ import { updateRandomRedux } from '../../data/store/slices/operationPerf.slice';
 import { loadPipeSelection, resetPipeSelection } from '../../data/store/slices/pipeSelection.slice';
 import { mapIterable } from '../../utils/IterableHelpers';
 import useLogging from './useLogging.hook';
-import type { LoadGraphParams, LoadTemporalEpochParams } from '../components/graph-selector/GraphSelector';
 
 const usePerfAnalyzerFileLoader = () => {
     const dispatch = useDispatch();
@@ -42,7 +41,8 @@ const usePerfAnalyzerFileLoader = () => {
     const [error, setError] = useState<string | null>(null);
     const logging = useLogging();
     const { setCluster } = useContext<ClusterModel>(ClusterContext);
-    const { setActiveGraph, loadGraphOnChips, resetGraphOnChipState } = useContext(GraphOnChipContext);
+    const { setActiveGraph, loadGraphOnChips, resetGraphOnChipState, getGraphRelationshipByGraphName } =
+        useContext(GraphOnChipContext);
     const navigate = useNavigate();
     const location: Location<LocationState> = useLocation();
     const logger = useLogging();
@@ -157,15 +157,22 @@ const usePerfAnalyzerFileLoader = () => {
         dispatch(setIsLoadingFolder(false));
     };
 
-    const loadPerfAnalyzerGraph = ({ epoch, graphName, chipId }: LoadGraphParams) => {
+    const loadPerfAnalyzerGraph = (graphName: string) => {
         if (selectedFolder) {
+            const graphRelationship = getGraphRelationshipByGraphName(graphName);
+
+            if (!graphRelationship) {
+                return;
+            }
+
             dispatch(closeDetailedView());
             setActiveGraph(graphName);
+
             navigate('/render', {
                 state: {
-                    epoch,
+                    epoch: graphRelationship.temporalEpoch,
                     graphName,
-                    chipId,
+                    chipId: graphRelationship.chipId,
                 },
             });
         } else {
@@ -173,7 +180,7 @@ const usePerfAnalyzerFileLoader = () => {
         }
     };
 
-    const loadTemporalEpoch = ({ epoch }: LoadTemporalEpochParams) => {
+    const loadTemporalEpoch = (epoch: number) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
             navigate('/render', {

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -47,7 +47,7 @@ const usePerfAnalyzerFileLoader = () => {
     const logger = useLogging();
 
     useEffect(() => {
-        console.log('location.state', location.state?.graphName);
+        console.log('location.state', location.state);
         dispatch(updateRandomRedux(Math.random()));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [location.state]);
@@ -156,21 +156,20 @@ const usePerfAnalyzerFileLoader = () => {
         dispatch(setIsLoadingFolder(false));
     };
 
-    const loadPerfAnalyzerGraph = (graphName: string, temporalEpoch: number) => {
+    const loadPerfAnalyzerGraph = (state: LocationState) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
-            setActiveGraph(graphName);
-            navigate('/render', { state: { graphName, epoch: temporalEpoch } });
+            setActiveGraph(state.graphName ?? '');
+            navigate('/render', { state });
         } else {
             logging.error('Attempted to load graph but no folder path was available');
         }
     };
 
-    const loadTemporalEpoch = (epoch: number) => {
+    const loadTemporalEpoch = (state: LocationState) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
-            // setActiveGraph(graphName);
-            navigate('/render', { state: { epoch } });
+            navigate('/render', { state });
         } else {
             logging.error('Attempted to load epoch but no folder path was available');
         }

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -22,7 +22,13 @@ import { ClusterContext, ClusterModel } from '../../data/ClusterContext';
 import type GraphOnChip from '../../data/GraphOnChip';
 import type { NodeInitialState } from '../../data/GraphOnChip';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
-import type { EpochAndLinkStates, FolderLocationType, LocationState, PipeSelection } from '../../data/StateTypes';
+import type {
+    EpochAndLinkStates,
+    FolderLocationType,
+    LocationState,
+    NavigateOptions,
+    PipeSelection,
+} from '../../data/StateTypes';
 import {
     initialLoadLinkData,
     initialLoadNormalizedOPs,
@@ -171,8 +177,12 @@ const usePerfAnalyzerFileLoader = () => {
                     epoch: graphRelationship.temporalEpoch,
                     graphName,
                     chipId: graphRelationship.chipId,
+                    previous: {
+                        graphName: location.state.graphName ?? '',
+                        path: location.pathname,
+                    },
                 },
-            });
+            } satisfies NavigateOptions);
         } else {
             logging.error('Attempted to load graph but no folder path was available');
         }
@@ -184,8 +194,12 @@ const usePerfAnalyzerFileLoader = () => {
             navigate('/render', {
                 state: {
                     epoch,
+                    previous: {
+                        graphName: location.state.graphName ?? '',
+                        path: location.pathname,
+                    },
                 },
-            });
+            } satisfies NavigateOptions);
         } else {
             logging.error('Attempted to load epoch but no folder path was available');
         }

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -108,7 +108,7 @@ const usePerfAnalyzerFileLoader = () => {
                         totalOpPerChip: [],
                         totalOps: 0,
                         normalizedTotalOps: 0,
-                        adjustedTotalOps: 0,
+                        initialNormalizedTotalOps: 0,
                     };
                 }
 
@@ -121,7 +121,10 @@ const usePerfAnalyzerFileLoader = () => {
                 };
 
                 const ops = totalOpsPerEpoch ?? 1;
-                linkDataByTemporalEpoch[graph.temporalEpoch].totalOps = Math.max(graphOnChip.totalOpCycles, ops);
+                const totalOps = Math.max(graphOnChip.totalOpCycles, ops);
+                linkDataByTemporalEpoch[graph.temporalEpoch].initialNormalizedTotalOps = totalOps;
+                linkDataByTemporalEpoch[graph.temporalEpoch].normalizedTotalOps = totalOps;
+                linkDataByTemporalEpoch[graph.temporalEpoch].totalOps = totalOps;
                 linkDataByTemporalEpoch[graph.temporalEpoch].totalOpPerChip[graph.chipId] = graphOnChip.totalOpCycles;
 
                 graphOnChipList.push(graphOnChip);

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -34,6 +34,7 @@ import { updateRandomRedux } from '../../data/store/slices/operationPerf.slice';
 import { loadPipeSelection, resetPipeSelection } from '../../data/store/slices/pipeSelection.slice';
 import { mapIterable } from '../../utils/IterableHelpers';
 import useLogging from './useLogging.hook';
+import type { LoadGraphParams, LoadTemporalEpochParams } from '../components/graph-selector/GraphSelector';
 
 const usePerfAnalyzerFileLoader = () => {
     const dispatch = useDispatch();
@@ -156,12 +157,6 @@ const usePerfAnalyzerFileLoader = () => {
         dispatch(setIsLoadingFolder(false));
     };
 
-    interface LoadGraphParams {
-        epoch: number;
-        graphName: string;
-        chipId: number;
-    }
-
     const loadPerfAnalyzerGraph = ({ epoch, graphName, chipId }: LoadGraphParams) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
@@ -177,10 +172,6 @@ const usePerfAnalyzerFileLoader = () => {
             logging.error('Attempted to load graph but no folder path was available');
         }
     };
-
-    interface LoadTemporalEpochParams {
-        epoch: number;
-    }
 
     const loadTemporalEpoch = ({ epoch }: LoadTemporalEpochParams) => {
         if (selectedFolder) {

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -177,7 +177,7 @@ const usePerfAnalyzerFileLoader = () => {
                     graphName,
                     chipId: graphRelationship.chipId,
                     previous: {
-                        graphName: location.state.graphName ?? '',
+                        graphName: location.state?.graphName ?? '',
                         path: location.pathname,
                     },
                 },
@@ -194,7 +194,7 @@ const usePerfAnalyzerFileLoader = () => {
                 state: {
                     epoch,
                     previous: {
-                        graphName: location.state.graphName ?? '',
+                        graphName: location.state?.graphName ?? '',
                         path: location.pathname,
                     },
                 },

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -156,20 +156,40 @@ const usePerfAnalyzerFileLoader = () => {
         dispatch(setIsLoadingFolder(false));
     };
 
-    const loadPerfAnalyzerGraph = (state: LocationState) => {
+    interface LoadGraphParams {
+        epoch: number;
+        graphName: string;
+        chipId: number;
+    }
+
+    const loadPerfAnalyzerGraph = ({ epoch, graphName, chipId }: LoadGraphParams) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
-            setActiveGraph(state.graphName ?? '');
-            navigate('/render', { state });
+            setActiveGraph(graphName);
+            navigate('/render', {
+                state: {
+                    epoch,
+                    graphName,
+                    chipId,
+                },
+            });
         } else {
             logging.error('Attempted to load graph but no folder path was available');
         }
     };
 
-    const loadTemporalEpoch = (state: LocationState) => {
+    interface LoadTemporalEpochParams {
+        epoch: number;
+    }
+
+    const loadTemporalEpoch = ({ epoch }: LoadTemporalEpochParams) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
-            navigate('/render', { state });
+            navigate('/render', {
+                state: {
+                    epoch,
+                },
+            });
         } else {
             logging.error('Attempted to load epoch but no folder path was available');
         }

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -96,7 +96,7 @@ const usePerfAnalyzerFileLoader = () => {
             const linkDataByGraphname: Record<string, EpochAndLinkStates> = {};
             const pipeSelectionData: PipeSelection[] = [];
             const totalOpsData: Record<string, number> = {};
-            const nodesDataPerGraph: Record<string, ReturnType<ComputeNode['generateInitialState']>[]> = {};
+            const nodesDataPerTemporalEpoch: Record<number, ReturnType<ComputeNode['generateInitialState']>[]> = {};
             const times = [];
             // eslint-disable-next-line no-restricted-syntax
             for (const graph of sortedGraphs) {
@@ -115,11 +115,11 @@ const usePerfAnalyzerFileLoader = () => {
                 totalOpsData[graph.name] = graphOnChip.totalOpCycles;
                 pipeSelectionData.push(...graphOnChip.generateInitialPipesSelectionState());
 
-                if (!nodesDataPerGraph[graph.temporalEpoch]) {
-                    nodesDataPerGraph[graph.temporalEpoch] = [];
+                if (!nodesDataPerTemporalEpoch[graph.temporalEpoch]) {
+                    nodesDataPerTemporalEpoch[graph.temporalEpoch] = [];
                 }
 
-                nodesDataPerGraph[graph.temporalEpoch].push(
+                nodesDataPerTemporalEpoch[graph.temporalEpoch].push(
                     ...mapIterable(graphOnChip.nodes, (node) => node.generateInitialState(graph.name)),
                 );
 
@@ -139,7 +139,7 @@ const usePerfAnalyzerFileLoader = () => {
             dispatch(loadPipeSelection(pipeSelectionData));
             dispatch(initialLoadTotalOPs(totalOpsData));
             dispatch(initialLoadNormalizedOPs({ perGraph: totalOpsNormalized, perEpoch: totalOpsPerEpoch }));
-            dispatch(initialLoadAllNodesData(nodesDataPerGraph));
+            dispatch(initialLoadAllNodesData(nodesDataPerTemporalEpoch));
 
             // console.table(times, ['graph', 'time']);
             // console.log('total', performance.now() - entireRunStartTime, 'ms');

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -20,7 +20,7 @@ import { type Location, useLocation, useNavigate } from 'react-router-dom';
 import { sortPerfAnalyzerGraphnames } from 'utils/FilenameSorters';
 import { ClusterContext, ClusterModel } from '../../data/ClusterContext';
 import type GraphOnChip from '../../data/GraphOnChip';
-import type { ComputeNode } from '../../data/GraphOnChip';
+import type { NodeInitialState } from '../../data/GraphOnChip';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 import type { EpochAndLinkStates, FolderLocationType, LocationState, PipeSelection } from '../../data/StateTypes';
 import {
@@ -96,7 +96,7 @@ const usePerfAnalyzerFileLoader = () => {
             const linkDataByGraphname: Record<string, EpochAndLinkStates> = {};
             const pipeSelectionData: PipeSelection[] = [];
             const totalOpsData: Record<string, number> = {};
-            const nodesDataPerTemporalEpoch: Record<number, ReturnType<ComputeNode['generateInitialState']>[]> = {};
+            const nodesDataPerTemporalEpoch: Record<number, NodeInitialState[]> = {};
             const times = [];
             // eslint-disable-next-line no-restricted-syntax
             for (const graph of sortedGraphs) {

--- a/src/renderer/hooks/useSelectableGraphVertex.hook.ts
+++ b/src/renderer/hooks/useSelectableGraphVertex.hook.ts
@@ -25,11 +25,7 @@ const useSelectableGraphVertex = () => {
             return () => {
                 const operand = getOperand(operandName);
                 if (operand) {
-                    loadPerfAnalyzerGraph({
-                        epoch: operand.temporalEpoch,
-                        graphName: operand.graphName,
-                        chipId: operand.chipId,
-                    });
+                    loadPerfAnalyzerGraph(operand.graphName);
                 }
             };
         },

--- a/src/renderer/hooks/useSelectableGraphVertex.hook.ts
+++ b/src/renderer/hooks/useSelectableGraphVertex.hook.ts
@@ -25,7 +25,11 @@ const useSelectableGraphVertex = () => {
             return () => {
                 const operand = getOperand(operandName);
                 if (operand) {
-                    loadPerfAnalyzerGraph(operand.graphName);
+                    loadPerfAnalyzerGraph({
+                        epoch: operand.temporalEpoch,
+                        graphName: operand.graphName,
+                        chipId: operand.chipId,
+                    });
                 }
             };
         },

--- a/src/renderer/views/MainRouteRenderer.tsx
+++ b/src/renderer/views/MainRouteRenderer.tsx
@@ -8,9 +8,8 @@ import {
     getDockOpenState,
     getIsLoadingFolder,
 } from 'data/store/selectors/uiState.selectors';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
-import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 import { INITIAL_DETAILS_VIEW_HEIGHT } from '../../data/constants';
 import TenstorrentLogo from '../../main/assets/TenstorrentLogo';
 import GridRender from '../components/GridRender';
@@ -29,12 +28,11 @@ const MainRouteRenderer: React.FC<MainRouteRendererProps> = () => {
     const isDetailedViewOpen = useSelector(getDetailedViewOpenState);
     const detailedViewHeight = useSelector(getDetailedViewHeight);
     const loading = useSelector(getIsLoadingFolder);
-    const graphOnChip = useContext(GraphOnChipContext).getActiveGraphOnChip();
     const { error } = usePerfAnalyzerFileLoader();
 
     return (
         <div
-            className={`main-route ${isDockOpen ? 'dock-open' : ''} ${isDetailedViewOpen ? 'detailed-view-open' : ''} ${!loading && (error || !graphOnChip) ? 'invalid-data' : ''} ${loading ? 'loading-data' : ''}`}
+            className={`main-route ${isDockOpen ? 'dock-open' : ''} ${isDetailedViewOpen ? 'detailed-view-open' : ''} ${!loading && error ? 'invalid-data' : ''} ${loading ? 'loading-data' : ''}`}
             style={
                 {
                     '--js-bottom-dock-height': `${

--- a/src/renderer/views/MainRouteRenderer.tsx
+++ b/src/renderer/views/MainRouteRenderer.tsx
@@ -33,31 +33,29 @@ const MainRouteRenderer: React.FC<MainRouteRendererProps> = () => {
     const { error } = usePerfAnalyzerFileLoader();
 
     return (
-        <>
-            <div
-                className={`main-route ${isDockOpen ? 'dock-open' : ''} ${isDetailedViewOpen ? 'detailed-view-open' : ''} ${!loading && (error || !graphOnChip) ? 'invalid-data' : ''} ${loading ? 'loading-data' : ''}`}
-                style={
-                    {
-                        '--js-bottom-dock-height': `${
-                            isDetailedViewOpen ? detailedViewHeight : INITIAL_DETAILS_VIEW_HEIGHT
-                        }px`,
-                    } as React.CSSProperties
-                }
-            >
-                <div className='header'>
-                    <TenstorrentLogo />
-                    <TopHeaderComponent />
-                </div>
-                <SideBar />
-                <GridSidebar />
-                <GridRender />
-                <PropertiesPanel />
-                <BottomDock isActive={isDockOpen} />
-                <div className={`main-route-loading-overlay`}>
-                    <p>Loading data...</p>
-                </div>
+        <div
+            className={`main-route ${isDockOpen ? 'dock-open' : ''} ${isDetailedViewOpen ? 'detailed-view-open' : ''} ${!loading && (error || !graphOnChip) ? 'invalid-data' : ''} ${loading ? 'loading-data' : ''}`}
+            style={
+                {
+                    '--js-bottom-dock-height': `${
+                        isDetailedViewOpen ? detailedViewHeight : INITIAL_DETAILS_VIEW_HEIGHT
+                    }px`,
+                } as React.CSSProperties
+            }
+        >
+            <div className='header'>
+                <TenstorrentLogo />
+                <TopHeaderComponent />
             </div>
-        </>
+            <SideBar />
+            <GridSidebar />
+            <GridRender />
+            <PropertiesPanel />
+            <BottomDock isActive={isDockOpen} />
+            <div className='main-route-loading-overlay'>
+                <p>Loading data...</p>
+            </div>
+        </div>
     );
 };
 


### PR DESCRIPTION
Add memoization and move references around to make performance improve when rendering a large temporal epoch. Specifically, on Galaxy.