### PR TITLE
Fix: move op perf from redux

### DIFF
--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -29,7 +29,7 @@ import {
 } from './sources/GraphDescriptor';
 import { OpPerformanceByOp, PerfAnalyzerResultsJson } from './sources/PerfAnalyzerResults';
 import { QueueDescriptorJson, parsedQueueLocation } from './sources/QueueDescriptor';
-import { LinkState, type LinkStateCongestion, type NodeUID, PipeSelection } from './StateTypes';
+import { PipeSelection } from './StateTypes';
 import {
     Architecture,
     ComputeNodeType,
@@ -758,99 +758,6 @@ export default class GraphOnChip {
         return [...nodes];
     }
 
-    getAllLinksInitialState() {
-        const linksStateCongestionByNode: Record<NodeUID, LinkStateCongestion> = {};
-
-        forEach(this.nodes, (node) => {
-            if (!linksStateCongestionByNode[node.uid]) {
-                linksStateCongestionByNode[node.uid] = {
-                    linksByLinkId: {},
-                    ethLinkIds: [],
-                    offchipLinkIds: [],
-                    chipId: this.chipId,
-                    maxLinkSaturation: 0,
-                    offchipMaxSaturation: 0,
-                };
-            }
-
-            node.links.forEach((link) => {
-                linksStateCongestionByNode[node.uid].linksByLinkId[link.uid] = link.generateInitialState();
-            });
-            node.internalLinks.forEach((link) => {
-                linksStateCongestionByNode[node.uid].linksByLinkId[link.uid] = link.generateInitialState();
-
-                if (link.name === EthernetLinkName.ETH_IN || link.name === EthernetLinkName.ETH_OUT) {
-                    linksStateCongestionByNode[node.uid].ethLinkIds.push(link.uid);
-                }
-            });
-
-            switch (node.type) {
-                case ComputeNodeType.DRAM:
-                    linksStateCongestionByNode[node.uid].offchipLinkIds =
-                        node.dramChannel?.links.map((link) => {
-                            return link.uid;
-                        }) || [];
-                    break;
-                case ComputeNodeType.ETHERNET:
-                    linksStateCongestionByNode[node.uid].offchipLinkIds =
-                        [...node.internalLinks.values()].map((link) => {
-                            return link.uid;
-                        }) || [];
-                    break;
-
-                case ComputeNodeType.PCIE:
-                    linksStateCongestionByNode[node.uid].offchipLinkIds =
-                        [...node.internalLinks].map(([link]) => {
-                            return link.uid;
-                        }) || [];
-                    break;
-                default:
-                    break;
-            }
-        });
-
-        this.dramChannels.forEach((dramChannel) => {
-            // TODO: find correct node Uids for DRAM
-            const dramId = `DRAM-${this.chipId}-${dramChannel.id}`;
-
-            if (!linksStateCongestionByNode[dramId]) {
-                linksStateCongestionByNode[dramId] = {
-                    linksByLinkId: {},
-                    offchipLinkIds: [],
-                    ethLinkIds: [],
-                    chipId: this.chipId,
-                    maxLinkSaturation: 0,
-                    offchipMaxSaturation: 0,
-                };
-            }
-
-            dramChannel.links.forEach((link) => {
-                linksStateCongestionByNode[dramId].linksByLinkId[link.uid] = link.generateInitialState();
-
-                dramChannel.subchannels.forEach((subchannel) => {
-                    const dramSubchannelId = `${dramId}-${subchannel.subchannelId}`;
-
-                    if (!linksStateCongestionByNode[dramSubchannelId]) {
-                        linksStateCongestionByNode[dramSubchannelId] = {
-                            linksByLinkId: {},
-                            ethLinkIds: [],
-                            offchipLinkIds: [],
-                            chipId: this.chipId,
-                            maxLinkSaturation: 0,
-                            offchipMaxSaturation: 0,
-                        };
-                    }
-
-                    subchannel.links.forEach((subchannelLink) => {
-                        linksStateCongestionByNode[dramSubchannelId].linksByLinkId[subchannelLink.uid] =
-                            subchannelLink.generateInitialState();
-                    });
-                });
-            });
-        });
-        return linksStateCongestionByNode;
-    }
-
     get ethernetPipes(): PipeSegment[] {
         return [...this.nodes]
             .filter((node) => node.type === ComputeNodeType.ETHERNET)
@@ -1024,17 +931,6 @@ export abstract class NetworkLink {
         this.pipes = Object.entries(json.mapped_pipes).map(
             ([pipeId, bandwidth]) => new PipeSegment(pipeId, bandwidth, name, this.totalDataBytes),
         );
-    }
-
-    public generateInitialState(): LinkState {
-        return {
-            id: this.uid,
-            totalDataBytes: this.totalDataBytes,
-            bpc: 0,
-            saturation: 0,
-            maxBandwidth: this.maxBandwidth,
-            type: this.type,
-        } as LinkState;
     }
 }
 

--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -1034,9 +1034,6 @@ export abstract class NetworkLink {
             saturation: 0,
             maxBandwidth: this.maxBandwidth,
             type: this.type,
-            ...((this.name === EthernetLinkName.ETH_IN || this.name === EthernetLinkName.ETH_OUT) && {
-                ethDirection: this.name,
-            }),
         } as LinkState;
     }
 }
@@ -1157,6 +1154,7 @@ export class ComputeNode {
             }
             if (link.type === LinkType.ETHERNET) {
                 node.internalLinks.set(linkName, link as EthernetLink);
+                node.ethLinkNames.push(linkName);
             }
             if (link.type === LinkType.PCIE) {
                 node.internalLinks.set(linkName, link as PCIeLink);
@@ -1232,6 +1230,8 @@ export class ComputeNode {
     public links: Map<any, NOCLink> = new Map();
 
     public nocLinks: NOCLink[] = [];
+
+    public ethLinkNames: string[] = [];
 
     public offchipLinkIds: string[] = [];
 

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -4,7 +4,7 @@
 
 import type { RelativeRoutingType } from 'react-router-dom';
 import type { GraphVertexType } from './GraphNames';
-import { type EthernetLinkName, LinkType } from './Types';
+import { LinkType } from './Types';
 
 export interface ExperimentalFeaturesState {}
 
@@ -54,13 +54,11 @@ export interface NodeSelectionState {
 
 export interface LinkState {
     id: string;
-    ethDirection?: EthernetLinkName;
     totalDataBytes: number;
     bpc: number;
     saturation: number;
     maxBandwidth: number;
     type: LinkType;
-    normalizedSaturation: number;
 }
 
 export interface LinkGraphState {

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -4,7 +4,6 @@
 
 import type { RelativeRoutingType } from 'react-router-dom';
 import type { GraphVertexType } from './GraphNames';
-import { LinkType } from './Types';
 
 export interface ExperimentalFeaturesState {}
 
@@ -52,36 +51,10 @@ export interface NodeSelectionState {
     focusNode: string | null;
 }
 
-export interface LinkState {
-    id: string;
-    totalDataBytes: number;
-    bpc: number;
-    saturation: number;
-    maxBandwidth: number;
-    type: LinkType;
-}
-
-export interface LinkGraphState {
-    links: Record<string, LinkState>;
-    totalOps: number;
-    temporalEpoch: number;
-}
-
-export interface LinkStateCongestion {
-    linksByLinkId: Record<string, LinkState>;
-    ethLinkIds: string[];
-    offchipLinkIds: string[];
-    maxLinkSaturation: number;
-    offchipMaxSaturation: number;
-    chipId: number;
-}
-
 export interface NetworkCongestionState {
     linkSaturationTreshold: number;
     linksPerTemporalEpoch: {
-        linksStateCongestionByNode: Record<NodeUID, LinkStateCongestion>;
         totalOps: number;
-        totalOpPerChip: number[];
         normalizedTotalOps: number;
         initialNormalizedTotalOps: number;
     }[];

--- a/src/data/store/selectors/linkSaturation.selectors.ts
+++ b/src/data/store/selectors/linkSaturation.selectors.ts
@@ -2,31 +2,15 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../createStore';
-
-export const getEthLinkStateListForNode = createSelector(
-    (state: RootState) => state.linkSaturation.linksPerTemporalEpoch,
-    (linksPerEpoch) => (temporalEpoch: number, nodeUid: string) => {
-        const nodeLinkState = linksPerEpoch[temporalEpoch]?.linksStateCongestionByNode?.[nodeUid] ?? {};
-
-        return Object.fromEntries(
-            Object.entries(nodeLinkState?.linksByLinkId ?? {}).filter(([linkUid]) =>
-                nodeLinkState.ethLinkIds.includes(linkUid),
-            ),
-        );
-    },
-);
 
 export const getOffchipLinkSaturationForNode = (temporalEpoch: number, nodeUid: string) => (state: RootState) =>
     state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.linksStateCongestionByNode[nodeUid]
         ?.offchipMaxSaturation ?? 0;
 export const getTotalOpsForGraph = (temporalEpoch: number) => (state: RootState) =>
     state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.totalOps || 0;
-export const getEpochNormalizedTotalOps = createSelector(
-    (state: RootState) => state.linkSaturation.linksPerTemporalEpoch,
-    (linksPerTemporalEpoch) => linksPerTemporalEpoch.map(({ normalizedTotalOps }) => normalizedTotalOps),
-);
+export const getEpochNormalizedTotalOps = (temporalEpoch: number) => (state: RootState) =>
+    state.linkSaturation.linksPerTemporalEpoch[temporalEpoch].normalizedTotalOps;
 
 export const getEpochInitialNormalizedTotalOps = (temporalEpoch: number) => (state: RootState) =>
     state.linkSaturation.linksPerTemporalEpoch[temporalEpoch].initialNormalizedTotalOps;

--- a/src/data/store/selectors/linkSaturation.selectors.ts
+++ b/src/data/store/selectors/linkSaturation.selectors.ts
@@ -5,9 +5,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../createStore';
 
-export const getNodeLinksData = (temporalEpoch: number, nodeUid: string) => (state: RootState) =>
-    state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.linksStateCongestionByNode[nodeUid];
-
 export const getEthLinkStateListForNode = createSelector(
     (state: RootState) => state.linkSaturation.linksPerTemporalEpoch,
     (linksPerEpoch) => (temporalEpoch: number, nodeUid: string) => {

--- a/src/data/store/selectors/linkSaturation.selectors.ts
+++ b/src/data/store/selectors/linkSaturation.selectors.ts
@@ -8,21 +8,6 @@ import { RootState } from '../createStore';
 export const getNodeLinksData = (temporalEpoch: number, nodeUid: string) => (state: RootState) =>
     state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.linksStateCongestionByNode[nodeUid];
 
-export const getLinkSaturarionState = (temporalEpoch: number, nodeUid: string, linkUid: string) => (state: RootState) =>
-    state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.linksStateCongestionByNode[nodeUid]?.linksByLinkId[
-        linkUid
-    ];
-
-export const getLinkStaturationStateList = createSelector(
-    (state: RootState) => state.linkSaturation.linksPerTemporalEpoch,
-    (linksPerEpoch) => (temporalEpoch: number, nodeUid: string, linkUidList: string[]) =>
-        Object.fromEntries(
-            Object.entries(
-                linksPerEpoch[temporalEpoch]?.linksStateCongestionByNode[nodeUid]?.linksByLinkId ?? {},
-            )?.filter(([linkUid]) => linkUidList.includes(linkUid)),
-        ),
-);
-
 export const getEthLinkStateListForNode = createSelector(
     (state: RootState) => state.linkSaturation.linksPerTemporalEpoch,
     (linksPerEpoch) => (temporalEpoch: number, nodeUid: string) => {

--- a/src/data/store/selectors/linkSaturation.selectors.ts
+++ b/src/data/store/selectors/linkSaturation.selectors.ts
@@ -4,9 +4,6 @@
 
 import { RootState } from '../createStore';
 
-export const getOffchipLinkSaturationForNode = (temporalEpoch: number, nodeUid: string) => (state: RootState) =>
-    state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.linksStateCongestionByNode[nodeUid]
-        ?.offchipMaxSaturation ?? 0;
 export const getTotalOpsForGraph = (temporalEpoch: number) => (state: RootState) =>
     state.linkSaturation.linksPerTemporalEpoch[temporalEpoch]?.totalOps || 0;
 export const getEpochNormalizedTotalOps = (temporalEpoch: number) => (state: RootState) =>

--- a/src/data/store/slices/linkSaturation.slice.ts
+++ b/src/data/store/slices/linkSaturation.slice.ts
@@ -4,7 +4,7 @@
 
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { LinkState, NetworkCongestionState } from 'data/StateTypes';
+import { NetworkCongestionState } from 'data/StateTypes';
 import { LinkType, NOC } from 'data/Types';
 import {
     AICLK_INITIAL_MHZ,
@@ -25,18 +25,6 @@ const networkCongestionInitialState: NetworkCongestionState = {
     showNOC1: true,
 };
 
-const getInitialCLKValues = (state: NetworkCongestionState) => {
-    const DRAMBandwidthBytes = state.DRAMBandwidthGBs * 1000 * 1000 * 1000; // there is a reason why this is not 1024
-    const PCIBandwidthGBs = state.PCIBandwidthGBs * 1000 * 1000 * 1000; // there is a reason why this is not 1024
-    const CLKHz = state.CLKMHz * 1000 * 1000;
-
-    return {
-        DRAMBandwidthBytes,
-        PCIBandwidthGBs,
-        CLKHz,
-    };
-};
-
 const linkSaturationSlice = createSlice({
     name: 'linkSaturation',
     initialState: networkCongestionInitialState,
@@ -47,37 +35,9 @@ const linkSaturationSlice = createSlice({
         updateTotalOPs: (state, action: PayloadAction<{ temporalEpoch: number; totalOps: number }>) => {
             const { temporalEpoch, totalOps } = action.payload;
             const temporalEpochState = state.linksPerTemporalEpoch[temporalEpoch];
-            const { DRAMBandwidthBytes, PCIBandwidthGBs, CLKHz } = getInitialCLKValues(state);
 
             if (temporalEpochState) {
                 temporalEpochState.totalOps = totalOps;
-                Object.entries(temporalEpochState.linksStateCongestionByNode).forEach(
-                    ([nodeUid, { linksByLinkId: links, offchipLinkIds }]) => {
-                        Object.values(links).forEach((linkState) => {
-                            if (linkState.type === LinkType.ETHERNET) {
-                                linkState.maxBandwidth = ETH_BANDWIDTH_INITIAL_GBS;
-                            } else if (linkState.type === LinkType.DRAM) {
-                                linkState.maxBandwidth = DRAMBandwidthBytes / CLKHz;
-                            } else if (linkState.type === LinkType.PCIE) {
-                                linkState.maxBandwidth = PCIBandwidthGBs / CLKHz;
-                            }
-                            const { bpc, linkSaturation, maxLinkSaturation, offchipMaxSaturation } =
-                                INTERNAL_calculateLinkSaturationMetrics({
-                                    link: linkState,
-                                    totalOpCycles: totalOps,
-                                    linkListByLinkId: links,
-                                    offchipLinkIds,
-                                });
-
-                            linkState.bpc = bpc;
-                            linkState.saturation = linkSaturation;
-                            temporalEpochState.linksStateCongestionByNode[nodeUid].maxLinkSaturation =
-                                maxLinkSaturation;
-                            temporalEpochState.linksStateCongestionByNode[nodeUid].offchipMaxSaturation =
-                                offchipMaxSaturation;
-                        });
-                    },
-                );
             }
         },
         updateEpochNormalizedOP: (state, action: PayloadAction<{ epoch: number; updatedValue: number }>) => {
@@ -86,53 +46,15 @@ const linkSaturationSlice = createSlice({
         },
         initialLoadLinkData: (state, action: PayloadAction<NetworkCongestionState['linksPerTemporalEpoch']>) => {
             state.linksPerTemporalEpoch = action.payload;
-
-            action.payload.forEach(({ linksStateCongestionByNode, totalOpPerChip }) => {
-                const { DRAMBandwidthBytes, PCIBandwidthGBs, CLKHz } = getInitialCLKValues(state);
-
-                Object.entries(linksStateCongestionByNode).forEach(
-                    ([nodeUid, { linksByLinkId: links, chipId, offchipLinkIds }]) => {
-                        Object.values(links).forEach((linkState) => {
-                            if (linkState.type === LinkType.ETHERNET) {
-                                linkState.maxBandwidth = ETH_BANDWIDTH_INITIAL_GBS;
-                            } else if (linkState.type === LinkType.DRAM) {
-                                linkState.maxBandwidth = DRAMBandwidthBytes / CLKHz;
-                            } else if (linkState.type === LinkType.PCIE) {
-                                linkState.maxBandwidth = PCIBandwidthGBs / CLKHz;
-                            }
-
-                            if (linkState.bpc === 0 && linkState.totalDataBytes > 0) {
-                                linkState.bpc = linkState.totalDataBytes / totalOpPerChip[chipId];
-                            }
-
-                            const { bpc, linkSaturation, maxLinkSaturation, offchipMaxSaturation } =
-                                INTERNAL_calculateLinkSaturationMetrics({
-                                    link: linkState,
-                                    totalOpCycles: totalOpPerChip[chipId],
-                                    linkListByLinkId: links,
-                                    offchipLinkIds,
-                                });
-
-                            linkState.bpc = bpc;
-                            linkState.saturation = linkSaturation;
-                            linksStateCongestionByNode[nodeUid].maxLinkSaturation = maxLinkSaturation;
-                            linksStateCongestionByNode[nodeUid].offchipMaxSaturation = offchipMaxSaturation;
-                        });
-                    },
-                );
-            });
         },
         updateCLK: (state, action: PayloadAction<number>) => {
             state.CLKMHz = action.payload;
-            updateDRAMLinks(state);
         },
         updateDRAMBandwidth: (state, action: PayloadAction<number>) => {
             state.DRAMBandwidthGBs = action.payload;
-            updateDRAMLinks(state);
         },
         updatePCIBandwidth: (state, action: PayloadAction<number>) => {
             state.PCIBandwidthGBs = action.payload;
-            updatePCILinks(state);
         },
         updateShowLinkSaturation: (state, action: PayloadAction<boolean>) => {
             state.showLinkSaturation = action.payload;
@@ -150,103 +72,6 @@ const linkSaturationSlice = createSlice({
         },
     },
 });
-
-const updateDRAMLinks = (state: NetworkCongestionState) => {
-    const { DRAMBandwidthBytes, CLKHz } = getInitialCLKValues(state);
-
-    Object.values(state.linksPerTemporalEpoch).forEach((epochState) => {
-        Object.entries(epochState.linksStateCongestionByNode).forEach(
-            ([nodeUid, { linksByLinkId: links, offchipLinkIds }]) => {
-                Object.values(links).forEach((linkState) => {
-                    if (linkState.type === LinkType.DRAM) {
-                        linkState.maxBandwidth = DRAMBandwidthBytes / CLKHz;
-                        const { bpc, linkSaturation, maxLinkSaturation, offchipMaxSaturation } =
-                            INTERNAL_calculateLinkSaturationMetrics({
-                                link: linkState,
-                                totalOpCycles: epochState.totalOps,
-                                linkListByLinkId: links,
-                                offchipLinkIds,
-                            });
-
-                        linkState.bpc = bpc;
-                        linkState.saturation = linkSaturation;
-                        epochState.linksStateCongestionByNode[nodeUid].maxLinkSaturation = maxLinkSaturation;
-                        epochState.linksStateCongestionByNode[nodeUid].offchipMaxSaturation = offchipMaxSaturation;
-                    }
-                });
-            },
-        );
-    });
-};
-
-const updatePCILinks = (state: NetworkCongestionState) => {
-    const { PCIBandwidthGBs, CLKHz } = getInitialCLKValues(state);
-
-    Object.values(state.linksPerTemporalEpoch).forEach((epochState) => {
-        Object.entries(epochState.linksStateCongestionByNode).forEach(
-            ([nodeUid, { linksByLinkId: links, offchipLinkIds }]) => {
-                Object.values(links).forEach((linkState) => {
-                    if (linkState.type === LinkType.PCIE) {
-                        linkState.maxBandwidth = PCIBandwidthGBs / CLKHz;
-                        const { bpc, linkSaturation, maxLinkSaturation, offchipMaxSaturation } =
-                            INTERNAL_calculateLinkSaturationMetrics({
-                                link: linkState,
-                                totalOpCycles: epochState.totalOps,
-                                linkListByLinkId: links,
-                                offchipLinkIds,
-                            });
-
-                        linkState.bpc = bpc;
-                        linkState.saturation = linkSaturation;
-                        epochState.linksStateCongestionByNode[nodeUid].maxLinkSaturation = maxLinkSaturation;
-                        epochState.linksStateCongestionByNode[nodeUid].offchipMaxSaturation = offchipMaxSaturation;
-                    }
-                });
-            },
-        );
-    });
-};
-
-interface INTERNAL_LinkStaturationMetrics {
-    link: LinkState;
-    totalOpCycles: number;
-    linkListByLinkId: Record<string, LinkState>;
-    offchipLinkIds: string[];
-}
-
-const INTERNAL_calculateLinkSaturationMetrics = ({
-    link,
-    totalOpCycles,
-    linkListByLinkId,
-    offchipLinkIds,
-}: INTERNAL_LinkStaturationMetrics) => {
-    const newLinkSaturation = (link.bpc / link.maxBandwidth) * 100;
-
-    return {
-        bpc: link.totalDataBytes / totalOpCycles,
-        linkSaturation: newLinkSaturation,
-        ...Object.entries(linkListByLinkId).reduce(
-            (updatedSaturation, [linkId, { saturation }]) => {
-                if (linkId !== link.id) {
-                    updatedSaturation.maxLinkSaturation = Math.max(updatedSaturation.maxLinkSaturation, saturation);
-
-                    if (offchipLinkIds.includes(linkId)) {
-                        updatedSaturation.offchipMaxSaturation = Math.max(
-                            updatedSaturation.offchipMaxSaturation,
-                            saturation,
-                        );
-                    }
-                }
-
-                return updatedSaturation;
-            },
-            {
-                maxLinkSaturation: newLinkSaturation,
-                offchipMaxSaturation: newLinkSaturation,
-            },
-        ),
-    };
-};
 
 interface LinkSaturationMetrics {
     linkType: LinkType;
@@ -298,35 +123,6 @@ export const calculateLinkSaturationMetrics = ({
         bpc,
         maxBandwidth,
     };
-};
-
-export const calculateMaxLinkSaturation = (
-    linkUid: string,
-    linkSaturation: number,
-    linkListByLinkId: Record<string, LinkState>,
-) => {
-    return Object.entries(linkListByLinkId).reduce((updatedSaturation, [linkId, { saturation }]) => {
-        if (linkId !== linkUid) {
-            return Math.max(updatedSaturation, saturation);
-        }
-
-        return updatedSaturation;
-    }, linkSaturation);
-};
-
-export const calculateOffchipMaxSaturation = (
-    linkUid: string,
-    linkSaturation: number,
-    linkListByLinkId: Record<string, LinkState>,
-    offchipLinkIds: string[],
-) => {
-    return Object.entries(linkListByLinkId).reduce((updatedSaturation, [linkId, { saturation }]) => {
-        if (linkId !== linkUid && offchipLinkIds.includes(linkId)) {
-            return Math.max(updatedSaturation, saturation);
-        }
-
-        return updatedSaturation;
-    }, linkSaturation);
 };
 
 export const {

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -23,7 +23,6 @@ import OperationGroupRender from './node-grid-elements-components/OperationGroup
 import QueueHighlightRenderer from './node-grid-elements-components/QueueHighlightRenderer';
 import { ClusterChip } from '../../data/Cluster';
 import OffChipNodeLinkCongestionLayer from './node-grid-elements-components/OffChipNodeLinkCongestionLayer';
-import { getOffchipLinkSaturationForNode } from '../../data/store/selectors/linkSaturation.selectors';
 import NodePipeRenderer from './node-grid-elements-components/NodePipeRenderer';
 import NodeFocusPipeRenderer from './node-grid-elements-components/NodeFocusPipeRenderer';
 import AsyncComponent from './AsyncRenderer';
@@ -41,7 +40,6 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, temporalEpoch, 
     const uid = useSelector(getSelectedDetailsViewUID);
     const focusPipe = useSelector(getFocusPipe);
 
-    const offchipLinkSaturation = useSelector(getOffchipLinkSaturationForNode(temporalEpoch, node.uid));
     const showOpNames = useSelector(getShowOperationNames);
 
     // Use the top border to determine if the label should be shown.
@@ -106,7 +104,13 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, temporalEpoch, 
             {/* Congestion information */}
             <AsyncComponent renderer={() => <OperationCongestionLayer node={node} />} loadingContent='' />
             <AsyncComponent
-                renderer={() => <OffChipNodeLinkCongestionLayer offchipLinkSaturation={offchipLinkSaturation} />}
+                renderer={() => (
+                    <OffChipNodeLinkCongestionLayer
+                        temporalEpoch={temporalEpoch}
+                        offchipLinkIds={node.offchipLinkIds}
+                        links={node.links}
+                    />
+                )}
                 loadingContent=''
             />
 

--- a/src/renderer/components/NodeGridElement.tsx
+++ b/src/renderer/components/NodeGridElement.tsx
@@ -23,7 +23,7 @@ import OperationGroupRender from './node-grid-elements-components/OperationGroup
 import QueueHighlightRenderer from './node-grid-elements-components/QueueHighlightRenderer';
 import { ClusterChip } from '../../data/Cluster';
 import OffChipNodeLinkCongestionLayer from './node-grid-elements-components/OffChipNodeLinkCongestionLayer';
-import { getNodeLinksData, getOffchipLinkSaturationForNode } from '../../data/store/selectors/linkSaturation.selectors';
+import { getOffchipLinkSaturationForNode } from '../../data/store/selectors/linkSaturation.selectors';
 import NodePipeRenderer from './node-grid-elements-components/NodePipeRenderer';
 import NodeFocusPipeRenderer from './node-grid-elements-components/NodeFocusPipeRenderer';
 import AsyncComponent from './AsyncRenderer';
@@ -41,7 +41,6 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, temporalEpoch, 
     const uid = useSelector(getSelectedDetailsViewUID);
     const focusPipe = useSelector(getFocusPipe);
 
-    const linksData = useSelector(getNodeLinksData(temporalEpoch, node.uid));
     const offchipLinkSaturation = useSelector(getOffchipLinkSaturationForNode(temporalEpoch, node.uid));
     const showOpNames = useSelector(getShowOperationNames);
 
@@ -119,7 +118,7 @@ const NodeGridElement: React.FC<NodeGridElementProps> = ({ node, temporalEpoch, 
             <AsyncComponent
                 renderer={() => (
                     <>
-                        <NodePipeRenderer node={node} linksData={linksData.linksByLinkId} />
+                        <NodePipeRenderer node={node} temporalEpoch={temporalEpoch} />
                         <NodeFocusPipeRenderer node={node} />
                     </>
                 )}

--- a/src/renderer/components/detailed-view-components/DetailedViewAXIRender.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewAXIRender.tsx
@@ -10,25 +10,17 @@ import DetailedViewPipeRenderer from './DetailedViewPipeRenderer';
 interface DetailedViewAXIRenderProps {
     links: DramBankLink[] | NetworkLink[];
     temporalEpoch: number;
-    nodeUid: string;
     filter: DramBankLinkName | NetworkLinkName | null;
     label: string;
 }
 
-export const DetailedViewAXIRender: React.FC<DetailedViewAXIRenderProps> = ({
-    links,
-    temporalEpoch,
-    nodeUid,
-    filter,
-    label,
-}) => {
+export const DetailedViewAXIRender: React.FC<DetailedViewAXIRenderProps> = ({ links, temporalEpoch, filter, label }) => {
     return (
         <div className='axi-dram-wrap'>
             <DetailedViewPipeRenderer
                 className='centered-svg'
                 links={links.filter((link) => (filter === null ? true : link.name === filter))}
                 temporalEpoch={temporalEpoch}
-                nodeUid={nodeUid}
             />
             <div className='axi-dram'>
                 <p className='label'>{label}</p>
@@ -40,16 +32,10 @@ export const DetailedViewAXIRender: React.FC<DetailedViewAXIRenderProps> = ({
 interface DetailedViewANOC2XIRenderProps {
     links: NOC2AXILink[] | NOCLink[];
     temporalEpoch: number;
-    nodeUid: string;
     noc: NOC;
 }
 
-export const DetailedViewNOC2AXIRender: React.FC<DetailedViewANOC2XIRenderProps> = ({
-    links,
-    temporalEpoch,
-    nodeUid,
-    noc,
-}) => {
+export const DetailedViewNOC2AXIRender: React.FC<DetailedViewANOC2XIRenderProps> = ({ links, temporalEpoch, noc }) => {
     return (
         <>
             <div className='noc2axi'>
@@ -59,7 +45,6 @@ export const DetailedViewNOC2AXIRender: React.FC<DetailedViewANOC2XIRenderProps>
                 className='centered-svg'
                 links={links.filter((link) => (noc === NOC.ANY ? true : link.noc === noc))}
                 temporalEpoch={temporalEpoch}
-                nodeUid={nodeUid}
             />
         </>
     );

--- a/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
@@ -61,7 +61,6 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                         return (
                             <div
                                 key={subchannel.subchannelId}
-                                // prettier-ignore
                                 className={`subchannel ${node.dramSubchannelId === subchannel.subchannelId ? 'current' : ''}`}
                             >
                                 {dram.subchannels.length > 1 && (
@@ -98,13 +97,11 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                                             links={noc0links}
                                             temporalEpoch={temporalEpoch}
                                             label='NOC0'
-                                            nodeUid={node.uid}
                                         />
                                         <DetailedViewNOC2AXIRender
                                             links={subchannel.links}
                                             temporalEpoch={temporalEpoch}
                                             noc={NOC.NOC0}
-                                            nodeUid={node.uid}
                                         />
                                     </div>
                                     <div className='col noc1'>
@@ -112,13 +109,11 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                                             links={noc1links}
                                             temporalEpoch={temporalEpoch}
                                             label='NOC1'
-                                            nodeUid={node.uid}
                                         />
                                         <DetailedViewNOC2AXIRender
                                             links={subchannel.links}
                                             temporalEpoch={temporalEpoch}
                                             noc={NOC.NOC1}
-                                            nodeUid={node.uid}
                                         />
                                     </div>
                                 </div>
@@ -137,14 +132,12 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                             <DetailedViewAXIRender
                                 links={dram.links}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 filter={DramBankLinkName.DRAM0_INOUT}
                                 label='AXI DRAM0'
                             />
                             <DetailedViewAXIRender
                                 links={dram.links}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 filter={DramBankLinkName.DRAM1_INOUT}
                                 label='AXI DRAM1'
                             />
@@ -154,7 +147,6 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                         <DetailedViewAXIRender
                             links={dram.links}
                             temporalEpoch={temporalEpoch}
-                            nodeUid={node.uid}
                             filter={DramBankLinkName.DRAM_INOUT}
                             label='Off-chip DRAM'
                         />

--- a/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewDRAM.tsx
@@ -169,7 +169,6 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                                 <LinkDetails
                                     key={link.name}
                                     link={link}
-                                    nodeUid={n.uid}
                                     temporalEpoch={temporalEpoch}
                                     index={nodeList.length > 1 ? index : -1}
                                     showEmpty={false}
@@ -183,20 +182,13 @@ const DetailedViewDRAMRenderer: React.FC<DetailedViewDRAMRendererProps> = ({ nod
                                 key={link.name}
                                 index={nodeList.length > 1 ? sub.subchannelId : -1}
                                 link={link}
-                                nodeUid={node.uid}
                                 temporalEpoch={temporalEpoch}
                                 showEmpty={false}
                             />
                         )),
                     )}
                     {dram.links.map((link) => (
-                        <LinkDetails
-                            key={link.name}
-                            nodeUid={node.uid}
-                            temporalEpoch={temporalEpoch}
-                            link={link}
-                            showEmpty={false}
-                        />
+                        <LinkDetails key={link.name} temporalEpoch={temporalEpoch} link={link} showEmpty={false} />
                     ))}
                 </div>
             </div>

--- a/src/renderer/components/detailed-view-components/DetailedViewETH.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewETH.tsx
@@ -42,7 +42,6 @@ const DetailedViewETHRenderer: React.FC<DetailedViewETHRendererProps> = ({ node,
                                         <DetailedViewNOCRouterRenderer
                                             links={noc0links}
                                             temporalEpoch={temporalEpoch}
-                                            nodeUid={node.uid}
                                             label='NOC0'
                                         />
                                     </div>
@@ -50,7 +49,6 @@ const DetailedViewETHRenderer: React.FC<DetailedViewETHRendererProps> = ({ node,
                                         <DetailedViewNOCRouterRenderer
                                             links={noc1links}
                                             temporalEpoch={temporalEpoch}
-                                            nodeUid={node.uid}
                                             label='NOC1'
                                         />
                                     </div>
@@ -61,7 +59,6 @@ const DetailedViewETHRenderer: React.FC<DetailedViewETHRendererProps> = ({ node,
                                         <DetailedViewPipeRenderer
                                             links={internalNOCLinks}
                                             temporalEpoch={temporalEpoch}
-                                            nodeUid={node.uid}
                                         />
                                     </div>
                                 </div>
@@ -76,7 +73,6 @@ const DetailedViewETHRenderer: React.FC<DetailedViewETHRendererProps> = ({ node,
                             <DetailedViewPipeRenderer
                                 links={internalNOCLinks}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 className='centered-svg'
                             />
                         </div>

--- a/src/renderer/components/detailed-view-components/DetailedViewETH.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewETH.tsx
@@ -87,13 +87,7 @@ const DetailedViewETHRenderer: React.FC<DetailedViewETHRendererProps> = ({ node,
                 <div className='node-links-wrap'>
                     {node.getInternalLinksForNode().map((link: NetworkLink) => {
                         return (
-                            <LinkDetails
-                                nodeUid={node.uid}
-                                temporalEpoch={temporalEpoch}
-                                key={link.name}
-                                link={link}
-                                showEmpty={false}
-                            />
+                            <LinkDetails temporalEpoch={temporalEpoch} key={link.name} link={link} showEmpty={false} />
                         );
                     })}
                 </div>

--- a/src/renderer/components/detailed-view-components/DetailedViewNOCRouterRenderer.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewNOCRouterRenderer.tsx
@@ -9,7 +9,6 @@ import DetailedViewPipeRenderer from './DetailedViewPipeRenderer';
 interface DetailedViewNOCRouterRendererProps {
     links: NetworkLink[];
     temporalEpoch: number;
-    nodeUid: string;
     label: string;
     className?: string;
 }
@@ -17,7 +16,6 @@ interface DetailedViewNOCRouterRendererProps {
 const DetailedViewNOCRouterRenderer: React.FC<DetailedViewNOCRouterRendererProps> = ({
     links,
     temporalEpoch,
-    nodeUid,
     label,
     className,
 }) => {
@@ -30,7 +28,7 @@ const DetailedViewNOCRouterRenderer: React.FC<DetailedViewNOCRouterRendererProps
                     Router
                 </p>
             </div>
-            <DetailedViewPipeRenderer links={links} temporalEpoch={temporalEpoch} nodeUid={nodeUid} />
+            <DetailedViewPipeRenderer links={links} temporalEpoch={temporalEpoch} />
         </>
     );
 };

--- a/src/renderer/components/detailed-view-components/DetailedViewPCIE.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewPCIE.tsx
@@ -41,13 +41,11 @@ const DetailedViewPCIERenderer: React.FC<DetailedViewPCIERendererProps> = ({ nod
                             <DetailedViewNOCRouterRenderer
                                 links={noc0links}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 label='NOC0'
                             />
                             <DetailedViewNOC2AXIRender
                                 links={noc0axi ? [noc0axi] : []}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 noc={NOC.ANY}
                             />
                         </div>
@@ -55,13 +53,11 @@ const DetailedViewPCIERenderer: React.FC<DetailedViewPCIERendererProps> = ({ nod
                             <DetailedViewNOCRouterRenderer
                                 links={noc1links}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 label='NOC1'
                             />
                             <DetailedViewNOC2AXIRender
                                 links={noc1axi ? [noc1axi] : []}
                                 temporalEpoch={temporalEpoch}
-                                nodeUid={node.uid}
                                 noc={NOC.ANY}
                             />
                         </div>
@@ -76,7 +72,6 @@ const DetailedViewPCIERenderer: React.FC<DetailedViewPCIERendererProps> = ({ nod
                         <DetailedViewAXIRender
                             links={offChipPCIe ? [offChipPCIe] : []}
                             temporalEpoch={temporalEpoch}
-                            nodeUid={node.uid}
                             filter={null}
                             label='PCIe'
                         />

--- a/src/renderer/components/detailed-view-components/DetailedViewPCIE.tsx
+++ b/src/renderer/components/detailed-view-components/DetailedViewPCIE.tsx
@@ -87,13 +87,7 @@ const DetailedViewPCIERenderer: React.FC<DetailedViewPCIERendererProps> = ({ nod
                 <div className='node-links-wrap'>
                     {node.getInternalLinksForNode().map((link: NetworkLink) => {
                         return (
-                            <LinkDetails
-                                key={link.name}
-                                nodeUid={node.uid}
-                                temporalEpoch={temporalEpoch}
-                                link={link}
-                                showEmpty={false}
-                            />
+                            <LinkDetails key={link.name} temporalEpoch={temporalEpoch} link={link} showEmpty={false} />
                         );
                     })}
                 </div>

--- a/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
+++ b/src/renderer/components/node-grid-elements-components/OffChipNodeLinkCongestionLayer.tsx
@@ -2,23 +2,63 @@
 //
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { getLinkSaturation, getShowLinkSaturation } from '../../../data/store/selectors/linkSaturation.selectors';
+import {
+    getCLKMhz,
+    getDRAMBandwidth,
+    getLinkSaturation,
+    getPCIBandwidth,
+    getShowLinkSaturation,
+    getTotalOpsForGraph,
+} from '../../../data/store/selectors/linkSaturation.selectors';
 import { calculateLinkCongestionColor, getOffChipCongestionStyles, toRGBA } from '../../../utils/DrawingAPI';
 import { getHighContrastState } from '../../../data/store/selectors/uiState.selectors';
+import { calculateLinkSaturationMetrics } from '../../../data/store/slices/linkSaturation.slice';
+import type { NOCLink } from '../../../data/GraphOnChip';
 
 interface OffChipNodeLinkCongestionLayerProps {
-    offchipLinkSaturation: number;
+    temporalEpoch: number;
+    links: Map<any, NOCLink>;
+    offchipLinkIds: string[];
 }
 
 /**
  * This renders a congestion layer for nodes with off chip links (DRAM, Ethernet, PCIe)  for those links
  */
-const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({ offchipLinkSaturation }) => {
+const OffChipNodeLinkCongestionLayer: FC<OffChipNodeLinkCongestionLayerProps> = ({
+    temporalEpoch,
+    links,
+    offchipLinkIds,
+}) => {
     const linkSaturationThreshold = useSelector(getLinkSaturation);
     const isHighContrast = useSelector(getHighContrastState);
     const showLinkSaturation = useSelector(getShowLinkSaturation);
+    const DRAMBandwidth = useSelector(getDRAMBandwidth);
+    const PCIBandwidth = useSelector(getPCIBandwidth);
+    const CLKMHz = useSelector(getCLKMhz);
+    const totalOps = useSelector(getTotalOpsForGraph(temporalEpoch));
+
+    const offchipLinkSaturation = useMemo(
+        () =>
+            [...links.entries()].reduce((maxSaturation, [linkId, link]) => {
+                if (offchipLinkIds.includes(linkId)) {
+                    const { saturation } = calculateLinkSaturationMetrics({
+                        DRAMBandwidth,
+                        PCIBandwidth,
+                        CLKMHz,
+                        linkType: link.type,
+                        totalDataBytes: link.totalDataBytes,
+                        totalOps,
+                    });
+
+                    return Math.max(maxSaturation, saturation);
+                }
+
+                return maxSaturation;
+            }, 0),
+        [CLKMHz, DRAMBandwidth, PCIBandwidth, links, offchipLinkIds, totalOps],
+    );
 
     let congestionStyle = {};
 

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -340,13 +340,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch }: ComputeNodeProps): R
                 <div className='node-links-wrap'>
                     <h4>Links</h4>
                     {node.getNOCLinksForNode().map((link: NOCLink) => (
-                        <LinkDetails
-                            key={link.name}
-                            link={link}
-                            nodeUid={node.uid}
-                            temporalEpoch={temporalEpoch}
-                            showEmpty
-                        />
+                        <LinkDetails key={link.name} link={link} temporalEpoch={temporalEpoch} showEmpty />
                     ))}
                 </div>
             )}

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -104,28 +104,19 @@ const usePerfAnalyzerFileLoader = () => {
 
                 if (!linkDataByTemporalEpoch[graph.temporalEpoch]) {
                     linkDataByTemporalEpoch[graph.temporalEpoch] = {
-                        linksStateCongestionByNode: {},
-                        totalOpPerChip: [],
                         totalOps: 0,
                         normalizedTotalOps: 0,
                         initialNormalizedTotalOps: 0,
                     };
                 }
 
-                const { linksStateCongestionByNode, totalOps: totalOpsPerEpoch } =
-                    linkDataByTemporalEpoch[graph.temporalEpoch];
-
-                linkDataByTemporalEpoch[graph.temporalEpoch].linksStateCongestionByNode = {
-                    ...linksStateCongestionByNode,
-                    ...graphOnChip.getAllLinksInitialState(),
-                };
+                const { totalOps: totalOpsPerEpoch } = linkDataByTemporalEpoch[graph.temporalEpoch];
 
                 const ops = totalOpsPerEpoch ?? 1;
                 const totalOps = Math.max(graphOnChip.totalOpCycles, ops);
                 linkDataByTemporalEpoch[graph.temporalEpoch].initialNormalizedTotalOps = totalOps;
                 linkDataByTemporalEpoch[graph.temporalEpoch].normalizedTotalOps = totalOps;
                 linkDataByTemporalEpoch[graph.temporalEpoch].totalOps = totalOps;
-                linkDataByTemporalEpoch[graph.temporalEpoch].totalOpPerChip[graph.chipId] = graphOnChip.totalOpCycles;
 
                 graphOnChipList.push(graphOnChip);
                 pipeSelectionData.push(...graphOnChip.generateInitialPipesSelectionState());


### PR DESCRIPTION
- Removed most of the op performance and link congestion parts from redux to instead be calculated locally and memoized.

## Known bugs
- Cluster view has a bug that doesn't show pipes and is slow. That will be addressed as a separate PR
- Calculations for link congestion are off, those will be addressed as a separate PR.