### PR TITLE
Fix: temporal epoch bugs

### DIFF
--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -48,7 +48,7 @@ const TopHeaderComponent: React.FC = () => {
     const location: Location<LocationState> = useLocation();
     const { chipId, epoch: temporalEpoch } = location.state;
 
-    const { resetGraphOnChipState, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
+    const { getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
     const graphOnChipList = getGraphOnChipListForTemporalEpoch(temporalEpoch, chipId);
 
     const { loadPerfAnalyzerFolder, openPerfAnalyzerFolderDialog, loadPerfAnalyzerGraph, loadTemporalEpoch } =
@@ -78,11 +78,8 @@ const TopHeaderComponent: React.FC = () => {
             dispatch(setSelectedRemoteFolder(newFolder));
         }
 
-        // TODO: do we need this call?
-        resetGraphOnChipState();
-
         if (checkLocalFolderExists(folderPath)) {
-            await loadPerfAnalyzerFolder(folderPath, newFolderLocationType);
+            const [firstGraph] = await loadPerfAnalyzerFolder(folderPath, newFolderLocationType);
 
             if (newFolderLocationType === 'local') {
                 sendEventToMain(ElectronEvents.UPDATE_WINDOW_TITLE, `(Local Folder) — ${getTestName(folderPath)}`);
@@ -92,6 +89,14 @@ const TopHeaderComponent: React.FC = () => {
                     formatRemoteFolderName(remoteConnectionConfig.selectedConnection, newFolder as RemoteFolder),
                 );
             }
+
+            navigate('/render', {
+                state: {
+                    epoch: firstGraph?.temporalEpoch ?? 0,
+                    chipId: firstGraph?.chipId ?? 0,
+                    graphName: firstGraph?.name ?? '',
+                },
+            });
         }
     };
 

--- a/src/renderer/components/bottom-dock/OperationsTable.tsx
+++ b/src/renderer/components/bottom-dock/OperationsTable.tsx
@@ -35,7 +35,6 @@ import SearchField from '../SearchField';
 import SelectableOperation, { SelectableOperationPerformance } from '../SelectableOperation';
 import { columnRenderer } from './SharedTable';
 import type { LocationState } from '../../../data/StateTypes';
-import type { BuildableOperation } from '../../../data/Graph';
 import AsyncComponent from '../AsyncRenderer';
 
 // TODO: This component will benefit from refactoring. in the interest of introducing a useful feature sooner this is staying as is for now.
@@ -55,19 +54,15 @@ function OperationsTable() {
         }
 
         let list: OpTableFields[] = [];
-        let selectedOperation: BuildableOperation | undefined;
+        const selectedOperationCores: ComputeNode[] = [];
 
         // eslint-disable-next-line no-restricted-syntax
         for (const { graphOnChip } of graphOnChipList) {
-            selectedOperation = graphOnChip.getOperation(selectedOperationName);
-
-            if (selectedOperation) {
-                break;
-            }
+            selectedOperationCores.push(...(graphOnChip.getOperation(selectedOperationName)?.cores ?? []));
         }
 
-        if (selectedOperation) {
-            list = selectedOperation.cores.map((core: ComputeNode) => {
+        if (selectedOperationCores.length > 0) {
+            list = selectedOperationCores.map((core: ComputeNode) => {
                 return {
                     name: core.opName,
                     ...core.perfAnalyzerResults,

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -20,8 +20,6 @@ interface GraphSelectorProps {
 }
 
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
-    // TODO: remove once temporal epoch are production ready
-    const IS_TEMPORAL_EPOCH_NAVIGATION_ENABLED = process.env.NODE_ENV === 'development';
     const location: Location<LocationState> = useLocation();
     const { chipId, epoch = -1 } = location?.state ?? {};
     const { getGraphsListByTemporalEpoch, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
@@ -42,7 +40,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                     <Menu>
                         {temporalEpochs.map(([temporalEpoch, graphRelationships], index) => (
                             <React.Fragment key={temporalEpoch}>
-                                {IS_TEMPORAL_EPOCH_NAVIGATION_ENABLED && graphRelationships.length > 1 && (
+                                {graphRelationships.length > 1 && (
                                     <>
                                         {index > 0 && <MenuDivider />}
                                         <MenuItem

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -42,7 +42,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                     <Menu>
                         {temporalEpochs.map(([temporalEpoch, graphRelationships], index) => (
                             <React.Fragment key={temporalEpoch}>
-                                {IS_TEMPORAL_EPOCH_NAVIGATION_ENABLED && (
+                                {IS_TEMPORAL_EPOCH_NAVIGATION_ENABLED && graphRelationships.length > 1 && (
                                     <>
                                         {index > 0 && <MenuDivider />}
                                         <MenuItem

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -24,6 +24,7 @@ import type { NodeInitialState } from '../../data/GraphOnChip';
 import { GraphOnChipContext } from '../../data/GraphOnChipContext';
 import type {
     FolderLocationType,
+    GraphRelationship,
     LocationState,
     NavigateOptions,
     NetworkCongestionState,
@@ -72,17 +73,19 @@ const usePerfAnalyzerFileLoader = () => {
         return folderPath;
     };
 
-    const loadFolder = async (folderPath: string): Promise<void> => {
+    const loadFolder = async (folderPath: string) => {
         resetGraphOnChipState();
         dispatch(resetPipeSelection());
         dispatch(resetNetworksState());
         setError(null);
         dispatch(setIsLoadingFolder(true));
 
+        let graphs: GraphRelationship[] = [];
+
         try {
             // TODO: needs gone once we are happy with performance
             const entireRunStartTime = performance.now();
-            const graphs = await getAvailableGraphNames(folderPath);
+            graphs = await getAvailableGraphNames(folderPath);
 
             if (!graphs.length) {
                 throw new Error(`No graphs found in\n${folderPath}`);
@@ -158,6 +161,8 @@ const usePerfAnalyzerFileLoader = () => {
 
         setCluster(await loadCluster(folderPath));
         dispatch(setIsLoadingFolder(false));
+
+        return graphs;
     };
 
     const loadPerfAnalyzerGraph = (graphName: string) => {
@@ -206,13 +211,15 @@ const usePerfAnalyzerFileLoader = () => {
     const loadPerfAnalyzerFolder = async (
         folderPath?: string | null,
         folderLocationType: FolderLocationType = 'local',
-    ): Promise<void> => {
+    ) => {
         if (folderPath) {
             dispatch(setApplicationMode(ApplicationMode.PERF_ANALYZER));
             dispatch(setSelectedFolderLocationType(folderLocationType));
 
-            await loadFolder(folderPath);
+            return loadFolder(folderPath);
         }
+
+        return [] as GraphRelationship[];
     };
 
     return {


### PR DESCRIPTION
- Fix problem when loading a dataset, selecting a temporal epoch and then loading another data set that doesn't have that epoch, caused an error in data loading.
- Remove temporal epoch indication if there is only one graph on the temporal epoch.
- Resolve reference for operations on operations table to work across temporal epochs.
- Remove temporal epoch flag