### PR TITLE
Fix: normalize graph listing

### DIFF
--- a/src/data/GraphOnChip.ts
+++ b/src/data/GraphOnChip.ts
@@ -11,7 +11,6 @@ import { DataIntegrityError, DataIntegrityErrorType } from './DataIntegrity';
 import { BuildableOperation, BuildableQueue, Operand } from './Graph';
 import { GraphVertexType, OperationName, QueueName } from './GraphNames';
 import type { Operation, Queue } from './GraphTypes';
-import { GraphVertex } from './GraphTypes';
 import {
     ChipDesignJSON,
     DramChannelJSON,
@@ -22,6 +21,7 @@ import {
 } from './JSONDataTypes';
 import { MeasurementDetails, OpPerfDetails } from './OpPerfDetails';
 import {
+    type CoreID,
     GraphDescriptorJSON,
     OperandJSON,
     OperationDescription,
@@ -45,6 +45,14 @@ import {
     PCIeLinkName,
     QueueLocation,
 } from './Types';
+
+interface CreateOperandParams {
+    name: string;
+    type: GraphVertexType;
+    inputPipesByCore?: Map<CoreID, string[]>;
+    outputPipesByCore?: Map<CoreID, string[]>;
+    pipesPerOperator?: { operator: string; pipes: string[]; index: number };
+}
 
 export default class GraphOnChip {
     private static NOC_ORDER: Map<NOCLinkName, number>;
@@ -244,10 +252,22 @@ export default class GraphOnChip {
             this.operationsByName.set(operation.name, operation);
         } else {
             const existingOperation = this.operationsByName.get(operation.name);
+
             if (existingOperation) {
                 existingOperation.assignInputs(operation.inputs);
                 existingOperation.assignOutputs(operation.outputs);
-                existingOperation.pipeIdsByCore = operation.pipeIdsByCore;
+
+                operation.inputPipesByCore.forEach((pipes, coreId) => {
+                    const existingPipes = existingOperation.inputPipesByCore.get(coreId) ?? [];
+
+                    existingOperation.inputPipesByCore.set(coreId, [...new Set([...existingPipes, ...pipes])]);
+                });
+
+                operation.outputPipesByCore.forEach((pipes, coreId) => {
+                    const existingPipes = existingOperation.outputPipesByCore.get(coreId) ?? [];
+
+                    existingOperation.outputPipesByCore.set(coreId, [...new Set([...existingPipes, ...pipes])]);
+                });
             }
         }
     }
@@ -276,52 +296,59 @@ export default class GraphOnChip {
         }
     }
 
-    protected createOperand(
-        name: string,
-        type: GraphVertexType,
-        pipesByCore?: Map<string, string[]>,
-        pipesPerOperator?: { operator: string; pipes: string[]; index: number },
-        from?: GraphVertex,
-        to?: GraphVertex,
-    ): Operand {
-        let operand: GraphVertex | undefined;
+    protected createOperand({
+        name,
+        type,
+        inputPipesByCore,
+        outputPipesByCore,
+        pipesPerOperator,
+    }: CreateOperandParams): Operand {
+        let operand: Operand | undefined;
 
         if (type === GraphVertexType.QUEUE) {
             if (!this.queuesByName.has(name)) {
                 this.queuesByName.set(name, new BuildableQueue(name));
             }
+
             operand = this.queuesByName.get(name) as BuildableQueue;
         }
+
         if (type === GraphVertexType.OPERATION) {
             if (!this.operationsByName.has(name)) {
                 this.operationsByName.set(name, new BuildableOperation(name, [], [], []));
             }
+
             operand = this.operationsByName.get(name) as BuildableOperation;
         }
+
+        if (operand === undefined) {
+            throw new Error(`Operand ${name} is neither a queue nor an operation`);
+        }
+
         if (pipesPerOperator) {
-            operand?.setPipesForOperator(
+            operand.setPipesForOperator(
                 pipesPerOperator.operator,
                 pipesPerOperator.pipes || [],
                 pipesPerOperator.index,
             );
         }
-        if (operand === undefined) {
-            throw new Error(`Operand ${name} is neither a queue nor an operation`);
+
+        if (inputPipesByCore) {
+            inputPipesByCore.forEach((pipes, coreId) => {
+                const existingPipes = operand.inputPipesByCore.get(coreId) ?? [];
+
+                operand.inputPipesByCore.set(coreId, [...new Set([...existingPipes, ...pipes])]);
+            });
         }
-        if (pipesByCore && pipesByCore.size > 0) {
-            if (operand.pipeIdsByCore.size > 0) {
-                pipesByCore.forEach((newPipeIds, coreId) => {
-                    if (operand!.pipeIdsByCore.has(coreId)) {
-                        const existingPipesIds = operand!.pipeIdsByCore.get(coreId) || [];
-                        pipesByCore.set(coreId, [...existingPipesIds, ...newPipeIds]);
-                    }
-                });
-                operand.pipeIdsByCore.forEach((pipeIds, coreId) => {
-                    pipesByCore.set(coreId, pipeIds);
-                });
-            }
-            operand.pipeIdsByCore = pipesByCore;
+
+        if (outputPipesByCore) {
+            outputPipesByCore.forEach((pipes, coreId) => {
+                const existingPipes = operand.outputPipesByCore.get(coreId) ?? [];
+
+                operand.outputPipesByCore.set(coreId, [...new Set([...existingPipes, ...pipes])]);
+            });
         }
+
         return operand;
     }
 
@@ -469,11 +496,11 @@ export default class GraphOnChip {
             Object.assign(augmentedChip, graphOnChip);
             const regex = /^(\d+)-(\d+)-(\d+)$/;
 
-            const pipesAsMap = (coresToPipes: Record<string, string[]>) => {
+            const coreToPipeRemap = (coresToPipes: Record<string, string[]>) => {
                 return new Map(
                     Object.entries(coresToPipes).map(([coreID, pipes]) => [
                         // TODO: we will need to address this to keep all core IDs consistent
-                        coreID.replace(regex, '$1-$3-$2'),
+                        coreID.replace(regex, '$1-$3-$2') as string,
                         pipes.map((pipeId) => pipeId.toString()),
                     ]),
                 );
@@ -483,62 +510,70 @@ export default class GraphOnChip {
                 const operation = augmentedChip.operationsByName.get(operationName);
 
                 if (operation === undefined) {
-                    // console.log(operationName, operation)
-                    /** this is perfectly normal, optopipe is a singlefile per temporal epoch and is multichip
-                     * we will want to capture ALL information for multichip routing */
-                    // console.warn(
-                    //     `Operation ${operationName} was found in the op-to-pipe map, but is not present in existing graphOnChip data; no core mapping available.`,
-                    // );
-                    // operation = new BuildableOperation(operationName, [], [], []);
-                    // augmentedChip.addOperation(operation);
-                    // TODO: we should add ALL operations but only add the operations that run on this graphOnChip to the augmentedChip. likely requires a separate structure (graph?)
-                    //
-                    return null;
+                    /**
+                     * This is perfectly normal, optopipe is a singlefile per temporal epoch and is multichip.
+                     */
+                    return;
                 }
 
                 const inputs = opJson.inputs.map((operandJson, index) => {
-                    const operatorPipes: string[] = Object.values(operandJson.pipes)
+                    const operatorPipes = Object.values(operandJson.pipes)
                         .map((pipes) => pipes.map((pipe) => pipe.toString()))
                         .flat();
-                    return augmentedChip.createOperand(
-                        operandJson.name,
-                        operandJson.type as GraphVertexType,
-                        pipesAsMap(operandJson.pipes),
-                        { operator: operation.name, pipes: operatorPipes, index },
-                    );
+                    return augmentedChip.createOperand({
+                        name: operandJson.name,
+                        type: operandJson.type as GraphVertexType,
+                        inputPipesByCore: coreToPipeRemap(operandJson.pipes),
+                        pipesPerOperator: { operator: operation.name, pipes: operatorPipes, index },
+                    });
                 });
                 const outputs = opJson.outputs.map((operandJson, index) => {
-                    const operatorPipes: string[] = Object.values(operandJson.pipes)
+                    const operatorPipes = Object.values(operandJson.pipes)
                         .map((pipes) => pipes.map((pipe) => pipe.toString()))
                         .flat();
-                    return augmentedChip.createOperand(
-                        operandJson.name,
-                        operandJson.type as GraphVertexType,
-                        pipesAsMap(operandJson.pipes),
-                        { operator: operation.name, pipes: operatorPipes, index },
-                    );
+                    return augmentedChip.createOperand({
+                        name: operandJson.name,
+                        type: operandJson.type as GraphVertexType,
+                        outputPipesByCore: coreToPipeRemap(operandJson.pipes),
+                        pipesPerOperator: { operator: operation.name, pipes: operatorPipes, index },
+                    });
                 });
 
                 // Extract queues from input operands
                 inputs.forEach((operand) => {
                     if (operand.vertexType === GraphVertexType.QUEUE) {
                         let queue = augmentedChip.queuesByName.get(operand.name);
+
                         if (!queue) {
                             queue = new BuildableQueue(operand.name);
                             augmentedChip.addQueue(queue);
                         }
-                        queue.assignOutputs([augmentedChip.createOperand(operationName, GraphVertexType.OPERATION)]);
+
+                        queue.assignOutputs([
+                            augmentedChip.createOperand({
+                                name: operationName,
+                                type: GraphVertexType.OPERATION,
+                            }),
+                        ]);
                     }
                 });
+
                 // Extract queues from output operands
                 outputs.forEach((operand) => {
                     if (operand.vertexType === GraphVertexType.QUEUE) {
                         let queue = augmentedChip.queuesByName.get(operand.name);
+
                         if (!queue) {
                             queue = new BuildableQueue(operand.name);
                             augmentedChip.addQueue(queue);
                         }
-                        queue.assignInputs([augmentedChip.createOperand(operationName, GraphVertexType.OPERATION)]);
+
+                        queue.assignInputs([
+                            augmentedChip.createOperand({
+                                name: operationName,
+                                type: GraphVertexType.OPERATION,
+                            }),
+                        ]);
                     }
                 });
 
@@ -546,7 +581,7 @@ export default class GraphOnChip {
                 operation.assignOutputs(outputs);
 
                 outputs.forEach((operand: Operand) => {
-                    operand.pipeIdsByCore.forEach((pipeIds, nodeId) => {
+                    operand.outputPipesByCore.forEach((pipeIds, nodeId) => {
                         pipeIds.forEach((pipeId) => {
                             const pipe = augmentedChip.pipes.get(pipeId);
                             if (pipe) {
@@ -567,7 +602,7 @@ export default class GraphOnChip {
                 });
 
                 inputs.forEach((operand: Operand) => {
-                    operand.pipeIdsByCore.forEach((pipeIds, nodeId) => {
+                    operand.inputPipesByCore.forEach((pipeIds, nodeId) => {
                         pipeIds.forEach((pipeId) => {
                             const pipe = augmentedChip.pipes.get(pipeId);
                             if (pipe) {
@@ -585,7 +620,6 @@ export default class GraphOnChip {
                         });
                     });
                 });
-                return operation;
             });
 
             return augmentedChip;
@@ -625,10 +659,16 @@ export default class GraphOnChip {
             //     // `core.id` is only an x-y locations and doesn't include Chip ID
             //     .map((core) => newChip.getNode(`${graphOnChip.chipId}-${core.id}`));
             const inputs = opDescriptor.inputs.map((operandJson) =>
-                newChip.createOperand(operandJson.name, operandJson.type),
+                newChip.createOperand({
+                    name: operandJson.name,
+                    type: operandJson.type,
+                }),
             );
             const outputs = opDescriptor.outputs.map((operandJson: OperandJSON) =>
-                newChip.createOperand(operandJson.name, operandJson.type),
+                newChip.createOperand({
+                    name: operandJson.name,
+                    type: operandJson.type,
+                }),
             );
 
             // Extract queues from input operands
@@ -639,12 +679,22 @@ export default class GraphOnChip {
                         queue = new BuildableQueue(operand.name);
                         graphOnChip.addQueue(queue);
                     }
-                    queue.assignOutputs([newChip.createOperand(opName, GraphVertexType.OPERATION)]);
+                    queue.assignOutputs([
+                        newChip.createOperand({
+                            name: opName,
+                            type: GraphVertexType.OPERATION,
+                        }),
+                    ]);
                 } else if (newChip.operationsByName.has(operand.name)) {
                     const op = newChip.operationsByName.get(operand.name);
                     if (op?.isOffchip) {
                         const operation = newChip.operationsByName.get(opName);
-                        operation?.assignInputs([newChip.createOperand(operand.name, GraphVertexType.OPERATION)]);
+                        operation?.assignInputs([
+                            newChip.createOperand({
+                                name: operand.name,
+                                type: GraphVertexType.OPERATION,
+                            }),
+                        ]);
                     }
                 }
             });
@@ -656,12 +706,22 @@ export default class GraphOnChip {
                         queue = new BuildableQueue(operand.name);
                         graphOnChip.addQueue(queue);
                     }
-                    queue.assignInputs([newChip.createOperand(opName, GraphVertexType.OPERATION)]);
+                    queue.assignInputs([
+                        newChip.createOperand({
+                            name: opName,
+                            type: GraphVertexType.OPERATION,
+                        }),
+                    ]);
                 } else if (newChip.operationsByName.has(operand.name)) {
                     const op = newChip.operationsByName.get(operand.name);
                     if (op?.isOffchip) {
                         const operation = newChip.operationsByName.get(opName);
-                        operation?.assignOutputs([newChip.createOperand(operand.name, GraphVertexType.OPERATION)]);
+                        operation?.assignOutputs([
+                            newChip.createOperand({
+                                name: operand.name,
+                                type: GraphVertexType.OPERATION,
+                            }),
+                        ]);
                     }
                 }
             });
@@ -1261,8 +1321,10 @@ export class ComputeNode {
     }
 }
 
+export type PipeID = string;
+
 export class Pipe {
-    readonly id: string;
+    readonly id: PipeID;
 
     nodes: ComputeNode[] = [];
 

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -96,13 +96,14 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                     graphsByEpoch.set(graphRelationship.temporalEpoch, []);
                 }
 
-                graphsByEpoch.set(graphRelationship.temporalEpoch, [
-                    ...graphsByEpoch.get(graphRelationship.temporalEpoch)!,
-                    {
-                        graph: graphRelationship,
-                        graphOnChip: graphOnChipList[graphName],
-                    },
-                ]);
+                const normalizedGraphsList = graphsByEpoch.get(graphRelationship.temporalEpoch)!;
+
+                normalizedGraphsList[graphRelationship.chipId] = {
+                    graph: graphRelationship,
+                    graphOnChip: graphOnChipList[graphName],
+                };
+
+                graphsByEpoch.set(graphRelationship.temporalEpoch, normalizedGraphsList);
 
                 return graphsByEpoch;
             },

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -10,7 +10,6 @@ import { Operand } from './Graph';
 
 interface OperandDescriptor {
     name: string;
-    graphName: string;
     temporalEpoch: number;
     type: GraphVertexType;
     operand: Operand;
@@ -62,7 +61,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                         .filter((op) => !op?.isOffchip ?? true)
                         .map((operation) => ({
                             name: operation.name,
-                            graphName: graphs[index].name,
                             temporalEpoch,
                             type: GraphVertexType.OPERATION,
                             operand: operation as Operand,
@@ -70,7 +68,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                         })),
                     ...[...graphOnChip.queues].map((queue) => ({
                         name: queue.name,
-                        graphName: graphs[index].name,
                         temporalEpoch,
                         type: GraphVertexType.QUEUE,
                         operand: queue as Operand,

--- a/src/data/GraphOnChipContext.tsx
+++ b/src/data/GraphOnChipContext.tsx
@@ -35,7 +35,6 @@ interface GraphOnChipContextType {
     loadGraphOnChips: (newChips: GraphOnChip[], graphs: GraphRelationship[]) => void;
     resetGraphOnChipState: () => void;
     getGraphRelationshipList: () => GraphRelationship[];
-    getGraphRelationshipByGraphName: (graphName: string) => GraphRelationship | undefined;
     getGraphsListByTemporalEpoch: () => Map<number, GraphRelationship[]>;
     getGraphOnChip: (temporalEpoch: number, chipId: number) => GraphOnChip | undefined;
     getOperand: (edgeName: string) => OperandDescriptor | undefined;
@@ -53,7 +52,6 @@ const GraphOnChipContext = createContext<GraphOnChipContextType>({
     loadGraphOnChips: () => {},
     resetGraphOnChipState: () => {},
     getGraphRelationshipList: () => [],
-    getGraphRelationshipByGraphName: () => undefined,
     getGraphsListByTemporalEpoch: () => new Map(),
     getGraphOnChip: () => undefined,
     getOperand: () => undefined,
@@ -143,11 +141,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         return [...state.graphs.values()];
     }, [state]);
 
-    const getGraphRelationshipByGraphName = useCallback(
-        (graphName: string) => state.graphs.get(graphName),
-        [state.graphs],
-    );
-
     const getGraphsListByTemporalEpoch = useCallback(() => {
         return [...state.graphs.values()].reduce<Map<number, GraphRelationship[]>>(
             (temporalEpochList, graphRelationship) => {
@@ -191,7 +184,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         () => ({
             loadGraphOnChips,
             getGraphRelationshipList,
-            getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
             resetGraphOnChipState,
@@ -201,7 +193,6 @@ const GraphOnChipProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         [
             loadGraphOnChips,
             getGraphRelationshipList,
-            getGraphRelationshipByGraphName,
             getGraphsListByTemporalEpoch,
             getGraphOnChip,
             resetGraphOnChipState,

--- a/src/data/StateTypes.ts
+++ b/src/data/StateTypes.ts
@@ -81,16 +81,12 @@ export type FolderLocationType = 'local' | 'remote';
 
 export interface LocationState {
     epoch: number;
-    /** @deprecated */
-    graphName?: string;
     chipId?: number;
     previous?: {
         path: string;
-        graphName: string;
     };
     next?: {
         path: string;
-        graphName: string;
     };
 }
 

--- a/src/renderer/components/GraphVertexDetails.tsx
+++ b/src/renderer/components/GraphVertexDetails.tsx
@@ -11,6 +11,7 @@ import { GraphVertex, Queue } from '../../data/GraphTypes';
 import { NOCLinkName } from '../../data/Types';
 import GraphVertexDetailsSelectables from './GraphVertexDetailsSelectables';
 import SelectablePipe from './SelectablePipe';
+import type { BuildableOperation } from '../../data/Graph';
 
 interface GraphVertexDetailsProps {
     graphNode: GraphVertex;
@@ -46,7 +47,10 @@ const GraphVertexDetails: FC<GraphVertexDetailsProps> = ({
             {inputs.length > 0 && <h5 className='io-label'>Inputs:</h5>}
             {inputs.map((operand, index) => (
                 <div className='operation-operand' key={`${index}-${graphNode.name}-${operand.name}`}>
-                    <GraphVertexDetailsSelectables operand={operand} />
+                    <GraphVertexDetailsSelectables
+                        operand={operand}
+                        isOffchip={(operand as BuildableOperation)?.isOffchip}
+                    />
                     {graphNode.vertexType === GraphVertexType.OPERATION && (
                         <ul className='scrollable-content'>
                             {operand.getPipesForOperatorIndexed(graphNode.name, index).map((pipeId) => (
@@ -79,7 +83,10 @@ const GraphVertexDetails: FC<GraphVertexDetailsProps> = ({
             {outputs.length > 0 && <h5 className='io-label'>Outputs:</h5>}
             {outputs.map((operand, index) => (
                 <div className='operation-operand' key={`${index}-${graphNode.name}-${operand.name}`}>
-                    <GraphVertexDetailsSelectables operand={operand} />
+                    <GraphVertexDetailsSelectables
+                        operand={operand}
+                        isOffchip={(operand as BuildableOperation)?.isOffchip}
+                    />
                     {graphNode.vertexType === GraphVertexType.OPERATION && (
                         <ul className='scrollable-content'>
                             {operand.getPipesForOperatorIndexed(graphNode.name, index).map((pipeId) => (

--- a/src/renderer/components/GraphVertexDetails.tsx
+++ b/src/renderer/components/GraphVertexDetails.tsx
@@ -16,16 +16,28 @@ import type { BuildableOperation } from '../../data/Graph';
 interface GraphVertexDetailsProps {
     graphNode: GraphVertex;
     showQueueDetails?: boolean;
+    isTemporalEpochView?: boolean;
 }
 
 const GraphVertexDetails: FC<GraphVertexDetailsProps> = ({
     graphNode,
     showQueueDetails = true,
+    isTemporalEpochView = false,
 }): React.ReactElement | null => {
     const inputs = [...graphNode.inputs];
     const outputs = [...graphNode.outputs];
+
     if (inputs.length === 0 && outputs.length === 0) {
         return null;
+    }
+
+    let queueLocationLabel = '';
+    if (graphNode.vertexType === GraphVertexType.QUEUE) {
+        queueLocationLabel = (graphNode as Queue).details?.processedLocation ?? '';
+
+        if (isTemporalEpochView) {
+            queueLocationLabel += ` (Device: ${(graphNode as Queue).details!['device-id']})`;
+        }
     }
 
     return (
@@ -37,10 +49,7 @@ const GraphVertexDetails: FC<GraphVertexDetailsProps> = ({
                               so we're not parsing raw data
                           */}
                         <h5 className='queue-detail-label'>Queue Location:</h5>
-                        <div className='queue-detail-value'>
-                            {(graphNode as Queue).details?.processedLocation} (Device{' '}
-                            {(graphNode as Queue).details!['device-id']})
-                        </div>
+                        <div className='queue-detail-value'>{queueLocationLabel}</div>
                     </div>
                 </div>
             )}
@@ -121,6 +130,7 @@ const GraphVertexDetails: FC<GraphVertexDetailsProps> = ({
 
 GraphVertexDetails.defaultProps = {
     showQueueDetails: true,
+    isTemporalEpochView: undefined,
 };
 
 export default GraphVertexDetails;

--- a/src/renderer/components/GraphVertexDetailsSelectables.tsx
+++ b/src/renderer/components/GraphVertexDetailsSelectables.tsx
@@ -12,6 +12,7 @@ interface GraphVertexDetailsSelectablesProps {
     stringFilter?: string;
     showType?: boolean;
     isOffchip?: boolean;
+    disabled?: boolean;
 }
 
 const GraphVertexDetailsSelectables: FC<GraphVertexDetailsSelectablesProps> = ({
@@ -19,6 +20,7 @@ const GraphVertexDetailsSelectables: FC<GraphVertexDetailsSelectablesProps> = ({
     stringFilter = '',
     showType = true,
     isOffchip,
+    disabled = false,
 }) => {
     const { selectOperand, selected, navigateToGraph } = useSelectableGraphVertex();
 
@@ -31,6 +33,7 @@ const GraphVertexDetailsSelectables: FC<GraphVertexDetailsSelectablesProps> = ({
             offchip={isOffchip}
             type={showType ? operand.vertexType : null}
             offchipClickHandler={navigateToGraph(operand.name)}
+            disabled={disabled}
         />
     );
 };
@@ -39,6 +42,7 @@ GraphVertexDetailsSelectables.defaultProps = {
     showType: true,
     stringFilter: '',
     isOffchip: undefined,
+    disabled: undefined,
 };
 
 export default GraphVertexDetailsSelectables;

--- a/src/renderer/components/SideBar.tsx
+++ b/src/renderer/components/SideBar.tsx
@@ -33,7 +33,6 @@ export const SideBar: React.FC<SideBarProps> = () => {
             state: {
                 epoch: -1,
                 previous: {
-                    graphName: location.state?.graphName ?? '',
                     path: location.pathname,
                 },
             },

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -125,7 +125,7 @@ const TopHeaderComponent: React.FC = () => {
                     <FolderPicker
                         icon={IconNames.FolderSharedOpen}
                         onSelectFolder={async () => {
-                            const folderPath = await openPerfAnalyzerFolderDialog();
+                            const folderPath = openPerfAnalyzerFolderDialog();
 
                             if (folderPath) {
                                 await updateSelectedFolder(folderPath, 'local');

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -135,7 +135,7 @@ const TopHeaderComponent: React.FC = () => {
                     />
                 </Tooltip2>
                 <GraphSelector
-                    onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
+                    onSelectGraph={(graphRelationship) => loadPerfAnalyzerGraph(graphRelationship)}
                     onSelectTemporalEpoch={(newTemporalEpoch) => loadTemporalEpoch(newTemporalEpoch)}
                 />
                 {/* TODO: reenable once we figure out how to disable the buttons from going to the home screen */}

--- a/src/renderer/components/TopHeaderComponent.tsx
+++ b/src/renderer/components/TopHeaderComponent.tsx
@@ -94,7 +94,6 @@ const TopHeaderComponent: React.FC = () => {
                 state: {
                     epoch: firstGraph?.temporalEpoch ?? 0,
                     chipId: firstGraph?.chipId ?? 0,
-                    graphName: firstGraph?.name ?? '',
                 },
             });
         }

--- a/src/renderer/components/folder-picker/LocalFolderSelector.tsx
+++ b/src/renderer/components/folder-picker/LocalFolderSelector.tsx
@@ -49,7 +49,7 @@ const LocalFolderOptions: FC = () => {
                     text={selectedFolderLocationType === 'local' ? getTestName(localFolderPath) : undefined}
                 />
                 <GraphSelector
-                    onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
+                    onSelectGraph={(graphRelationship) => loadPerfAnalyzerGraph(graphRelationship)}
                     onSelectTemporalEpoch={(temporalEpoch) => loadTemporalEpoch(temporalEpoch)}
                     disabled={selectedFolderLocationType === 'remote' || !localFolderPath}
                 />

--- a/src/renderer/components/folder-picker/LocalFolderSelector.tsx
+++ b/src/renderer/components/folder-picker/LocalFolderSelector.tsx
@@ -35,7 +35,7 @@ const LocalFolderOptions: FC = () => {
             <div className='buttons-container'>
                 <FolderPicker
                     onSelectFolder={async () => {
-                        const folderPath = await openPerfAnalyzerFolderDialog();
+                        const folderPath = openPerfAnalyzerFolderDialog();
 
                         await loadPerfAnalyzerFolder(folderPath);
 

--- a/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
+++ b/src/renderer/components/folder-picker/RemoteSyncConfigurator.tsx
@@ -260,7 +260,7 @@ const RemoteSyncConfigurator: FC = () => {
                         />
                     </Tooltip2>
                     <GraphSelector
-                        onSelectGraph={(graphName) => loadPerfAnalyzerGraph(graphName)}
+                        onSelectGraph={(graphRelationship) => loadPerfAnalyzerGraph(graphRelationship)}
                         onSelectTemporalEpoch={(temporalEpoch) => loadTemporalEpoch(temporalEpoch)}
                         disabled={
                             selectedFolderLocationType === 'local' || isSyncingRemoteFolder || isLoadingFolderList

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -18,7 +18,7 @@ function formatDisplayGraphName({
     chipId = -1,
     showTemporalEpoch = false,
 }: Partial<GraphRelationship & { showTemporalEpoch: boolean }>) {
-    return `${name} (${showTemporalEpoch ? `Epoch: ${temporalEpoch} ` : ''}Chip: ${chipId})`;
+    return `${name} (${showTemporalEpoch ? `Epoch ${temporalEpoch} ` : ''}Chip ${chipId})`;
 }
 
 interface GraphSelectorProps {

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -26,8 +26,8 @@ interface GraphSelectorProps {
 const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph, onSelectTemporalEpoch }) => {
     const location: Location<LocationState> = useLocation();
     const { chipId, epoch = -1 } = location?.state ?? {};
-    const { getGraphsListByTemporalEpoch, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
-    const temporalEpochs = [...getGraphsListByTemporalEpoch().entries()];
+    const { getGraphsByTemporalEpoch, getGraphOnChipListForTemporalEpoch } = useContext(GraphOnChipContext);
+    const temporalEpochs = [...getGraphsByTemporalEpoch().entries()];
     let selectedItemText = '';
 
     if (chipId !== undefined) {
@@ -55,7 +55,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                         />
                                     </>
                                 )}
-                                {graphRelationships.map((graphRelationship) => (
+                                {graphRelationships.map(({ graph: graphRelationship }) => (
                                     <MenuItem
                                         key={`${temporalEpoch}-${graphRelationship.name}`}
                                         text={formatDisplayGraphName(graphRelationship)}

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -12,6 +12,10 @@ import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import './GraphSelector.scss';
 import type { GraphRelationship, LocationState } from '../../../data/StateTypes';
 
+function formatDisplayGraphName({ name = '', temporalEpoch = -1, chipId = -1 }: Partial<GraphRelationship>) {
+    return `${name} (Epoch: ${temporalEpoch} Chip: ${chipId})`;
+}
+
 interface GraphSelectorProps {
     disabled?: boolean;
     label?: string;
@@ -27,7 +31,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
     let selectedItemText = '';
 
     if (chipId !== undefined) {
-        selectedItemText = getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph.name;
+        selectedItemText = formatDisplayGraphName(getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph ?? {});
     } else if (epoch >= 0) {
         selectedItemText = `Temporal Epoch ${epoch}`;
     }
@@ -54,7 +58,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                 {graphRelationships.map((graphRelationship) => (
                                     <MenuItem
                                         key={`${temporalEpoch}-${graphRelationship.name}`}
-                                        text={graphRelationship.name}
+                                        text={formatDisplayGraphName(graphRelationship)}
                                         onClick={() => onSelectGraph(graphRelationship)}
                                         className='graph-selector-graph'
                                     />

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -65,7 +65,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                 )}
                                 {graphRelationships.map(({ graph: graphRelationship }) => (
                                     <MenuItem
-                                        key={`${temporalEpoch}-${graphRelationship.name}`}
+                                        key={`${temporalEpoch}-${graphRelationship.chipId}`}
                                         text={formatDisplayGraphName({
                                             ...graphRelationship,
                                             showTemporalEpoch: graphRelationships.length <= 1,

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -10,12 +10,12 @@ import { type Location, useLocation } from 'react-router-dom';
 import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 
 import './GraphSelector.scss';
-import type { LocationState } from '../../../data/StateTypes';
+import type { GraphRelationship, LocationState } from '../../../data/StateTypes';
 
 interface GraphSelectorProps {
     disabled?: boolean;
     label?: string;
-    onSelectGraph: (graphName: string) => void;
+    onSelectGraph: (graphRelationship: GraphRelationship) => void;
     onSelectTemporalEpoch: (temporalEpoch: number) => void;
 }
 
@@ -55,7 +55,7 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                     <MenuItem
                                         key={`${temporalEpoch}-${graphRelationship.name}`}
                                         text={graphRelationship.name}
-                                        onClick={() => onSelectGraph(graphRelationship.name)}
+                                        onClick={() => onSelectGraph(graphRelationship)}
                                         className='graph-selector-graph'
                                     />
                                 ))}

--- a/src/renderer/components/graph-selector/GraphSelector.tsx
+++ b/src/renderer/components/graph-selector/GraphSelector.tsx
@@ -12,8 +12,13 @@ import { GraphOnChipContext } from '../../../data/GraphOnChipContext';
 import './GraphSelector.scss';
 import type { GraphRelationship, LocationState } from '../../../data/StateTypes';
 
-function formatDisplayGraphName({ name = '', temporalEpoch = -1, chipId = -1 }: Partial<GraphRelationship>) {
-    return `${name} (Epoch: ${temporalEpoch} Chip: ${chipId})`;
+function formatDisplayGraphName({
+    name = '',
+    temporalEpoch = -1,
+    chipId = -1,
+    showTemporalEpoch = false,
+}: Partial<GraphRelationship & { showTemporalEpoch: boolean }>) {
+    return `${name} (${showTemporalEpoch ? `Epoch: ${temporalEpoch} ` : ''}Chip: ${chipId})`;
 }
 
 interface GraphSelectorProps {
@@ -31,7 +36,10 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
     let selectedItemText = '';
 
     if (chipId !== undefined) {
-        selectedItemText = formatDisplayGraphName(getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph ?? {});
+        selectedItemText = formatDisplayGraphName({
+            ...(getGraphOnChipListForTemporalEpoch(epoch)[chipId]?.graph ?? {}),
+            showTemporalEpoch: getGraphOnChipListForTemporalEpoch(epoch).length <= 1,
+        });
     } else if (epoch >= 0) {
         selectedItemText = `Temporal Epoch ${epoch}`;
     }
@@ -58,7 +66,10 @@ const GraphSelector: FC<GraphSelectorProps> = ({ disabled, label, onSelectGraph,
                                 {graphRelationships.map(({ graph: graphRelationship }) => (
                                     <MenuItem
                                         key={`${temporalEpoch}-${graphRelationship.name}`}
-                                        text={formatDisplayGraphName(graphRelationship)}
+                                        text={formatDisplayGraphName({
+                                            ...graphRelationship,
+                                            showTemporalEpoch: graphRelationships.length <= 1,
+                                        })}
                                         onClick={() => onSelectGraph(graphRelationship)}
                                         className='graph-selector-graph'
                                     />

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -26,6 +26,7 @@ import LinkDetails from '../LinkDetails';
 import SelectableOperation from '../SelectableOperation';
 import SelectablePipe from '../SelectablePipe';
 import type { GraphRelationship } from '../../../data/StateTypes';
+import type { BuildableOperation } from '../../../data/Graph';
 
 interface ComputeNodeProps {
     node: ComputeNode;
@@ -200,7 +201,10 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, chipId }: ComputeNodeP
                                 <ul className='scrollable-content' key={operand.name}>
                                     <div title={operand.name}>
                                         <div style={{ fontSize: '12px' }}>
-                                            <GraphVertexDetailsSelectables operand={operand} />
+                                            <GraphVertexDetailsSelectables
+                                                operand={operand}
+                                                isOffchip={(operand as BuildableOperation)?.isOffchip}
+                                            />
                                             {operand.vertexType === GraphVertexType.OPERATION && (
                                                 <ul className='scrollable-content'>
                                                     {operand
@@ -249,7 +253,10 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, chipId }: ComputeNodeP
                                 <ul className='scrollable-content' key={operand.name}>
                                     <div title={operand.name}>
                                         <div style={{ fontSize: '12px' }}>
-                                            <GraphVertexDetailsSelectables operand={operand} />
+                                            <GraphVertexDetailsSelectables
+                                                operand={operand}
+                                                isOffchip={(operand as BuildableOperation)?.isOffchip}
+                                            />
                                             {operand.vertexType === GraphVertexType.OPERATION && (
                                                 <ul className='scrollable-content'>
                                                     {operand

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -227,7 +227,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, chipId }: ComputeNodeP
                                             )}
                                             {operand.vertexType === GraphVertexType.QUEUE && (
                                                 <ul className=' scrollable-content pipe-ids-for-core'>
-                                                    {operand.getPipeIdsForCore(node.uid).map((pipeId) => (
+                                                    {(operand.inputPipesByCore.get(node.uid) ?? []).map((pipeId) => (
                                                         <li key={`${operand.name}-${pipeId}`}>
                                                             <SelectablePipe
                                                                 pipeSegment={
@@ -279,7 +279,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, chipId }: ComputeNodeP
                                             )}
                                             {operand.vertexType === GraphVertexType.QUEUE && (
                                                 <ul className='scrollable-content pipe-ids-for-core'>
-                                                    {operand.getPipeIdsForCore(node.uid).map((pipeId) => (
+                                                    {(operand.outputPipesByCore.get(node.uid) ?? []).map((pipeId) => (
                                                         <li key={`${operand.name}-${pipeId}`}>
                                                             <SelectablePipe
                                                                 pipeSegment={

--- a/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/ComputeNodesPropertiesTab.tsx
@@ -200,10 +200,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, chipId }: ComputeNodeP
                                 <ul className='scrollable-content' key={operand.name}>
                                     <div title={operand.name}>
                                         <div style={{ fontSize: '12px' }}>
-                                            <GraphVertexDetailsSelectables
-                                                operand={operand}
-                                                isOffchip={chipId === undefined ? false : chipId === node.chipId}
-                                            />
+                                            <GraphVertexDetailsSelectables operand={operand} />
                                             {operand.vertexType === GraphVertexType.OPERATION && (
                                                 <ul className='scrollable-content'>
                                                     {operand
@@ -252,10 +249,7 @@ const ComputeNodePropertiesCard = ({ node, temporalEpoch, chipId }: ComputeNodeP
                                 <ul className='scrollable-content' key={operand.name}>
                                     <div title={operand.name}>
                                         <div style={{ fontSize: '12px' }}>
-                                            <GraphVertexDetailsSelectables
-                                                operand={operand}
-                                                isOffchip={chipId === undefined ? false : chipId === node.chipId}
-                                            />
+                                            <GraphVertexDetailsSelectables operand={operand} />
                                             {operand.vertexType === GraphVertexType.OPERATION && (
                                                 <ul className='scrollable-content'>
                                                     {operand

--- a/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/OperationsPropertiesTab.tsx
@@ -15,7 +15,7 @@ import SearchField from '../SearchField';
 import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 import type GraphOnChip from '../../../data/GraphOnChip';
 import type { GraphRelationship } from '../../../data/StateTypes';
-import type { Operation } from '../../../data/GraphTypes';
+import type { BuildableOperation } from '../../../data/Graph';
 
 const OperationsPropertiesTab = ({
     graphs,
@@ -41,7 +41,7 @@ const OperationsPropertiesTab = ({
                     });
 
                     return opMap;
-                }, new Map<string, { operation: Operation; chipId: number }>())
+                }, new Map<string, { operation: BuildableOperation; chipId: number }>())
                 .values(),
         ],
         [graphs],
@@ -108,7 +108,10 @@ const OperationsPropertiesTab = ({
                                             operand={operation}
                                             stringFilter={filterQuery}
                                             showType={false}
-                                            isOffchip={chipId === undefined ? false : chipId !== opChipId}
+                                            isOffchip={
+                                                operation.isOffchip ||
+                                                (chipId === undefined ? false : chipId !== opChipId)
+                                            }
                                         />
                                     }
                                     isOpen={allOpen}

--- a/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
@@ -109,7 +109,9 @@ const QueuesPropertiesTab = ({
                                 }
                                 isOpen={allOpen}
                             >
-                                {queue && <GraphVertexDetails graphNode={queue} />}
+                                {queue && (
+                                    <GraphVertexDetails graphNode={queue} isTemporalEpochView={chipId === undefined} />
+                                )}
                             </Collapsible>
                         }
                     />

--- a/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
+++ b/src/renderer/components/properties-panel/QueuesPropertiesTab.tsx
@@ -18,6 +18,7 @@ import GraphVertexDetailsSelectables from '../GraphVertexDetailsSelectables';
 import type GraphOnChip from '../../../data/GraphOnChip';
 import type { GraphRelationship } from '../../../data/StateTypes';
 import type { Queue } from '../../../data/GraphTypes';
+import { QueueLocation } from '../../../data/Types';
 
 const QueuesPropertiesTab = ({
     graphs,
@@ -105,6 +106,7 @@ const QueuesPropertiesTab = ({
                                         stringFilter={filterQuery}
                                         showType={false}
                                         isOffchip={chipId === undefined ? false : chipId !== queueChipId}
+                                        disabled={queue.details?.processedLocation === QueueLocation.HOST}
                                     />
                                 }
                                 isOpen={allOpen}

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -165,21 +165,15 @@ const usePerfAnalyzerFileLoader = () => {
         return graphs;
     };
 
-    const loadPerfAnalyzerGraph = (graphName: string) => {
+    const loadPerfAnalyzerGraph = ({ name, chipId, temporalEpoch }: GraphRelationship) => {
         if (selectedFolder) {
-            const graphRelationship = getGraphRelationshipByGraphName(graphName);
-
-            if (!graphRelationship) {
-                return;
-            }
-
             dispatch(closeDetailedView());
 
             navigate('/render', {
                 state: {
-                    epoch: graphRelationship.temporalEpoch,
-                    graphName,
-                    chipId: graphRelationship.chipId,
+                    epoch: temporalEpoch,
+                    graphName: name,
+                    chipId,
                     previous: {
                         graphName: location.state?.graphName ?? '',
                         path: location.pathname,

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -165,17 +165,15 @@ const usePerfAnalyzerFileLoader = () => {
         return graphs;
     };
 
-    const loadPerfAnalyzerGraph = ({ name, chipId, temporalEpoch }: GraphRelationship) => {
+    const loadPerfAnalyzerGraph = ({ chipId, temporalEpoch }: Omit<GraphRelationship, 'name'>) => {
         if (selectedFolder) {
             dispatch(closeDetailedView());
 
             navigate('/render', {
                 state: {
                     epoch: temporalEpoch,
-                    graphName: name,
                     chipId,
                     previous: {
-                        graphName: location.state?.graphName ?? '',
                         path: location.pathname,
                     },
                 },
@@ -192,7 +190,6 @@ const usePerfAnalyzerFileLoader = () => {
                 state: {
                     epoch,
                     previous: {
-                        graphName: location.state?.graphName ?? '',
                         path: location.pathname,
                     },
                 },

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -43,7 +43,7 @@ const usePerfAnalyzerFileLoader = () => {
     const [error, setError] = useState<string | null>(null);
     const logging = useLogging();
     const { setCluster } = useContext<ClusterModel>(ClusterContext);
-    const { loadGraphOnChips, resetGraphOnChipState, getGraphRelationshipByGraphName } = useContext(GraphOnChipContext);
+    const { loadGraphOnChips, resetGraphOnChipState } = useContext(GraphOnChipContext);
     const navigate = useNavigate();
     const location: Location<LocationState> = useLocation();
     const logger = useLogging();
@@ -53,7 +53,7 @@ const usePerfAnalyzerFileLoader = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [location.state]);
 
-    const openPerfAnalyzerFolderDialog = async () => {
+    const openPerfAnalyzerFolderDialog = () => {
         const folderList = dialog.showOpenDialogSync({
             properties: ['openDirectory'],
         });
@@ -63,7 +63,7 @@ const usePerfAnalyzerFileLoader = () => {
             return undefined;
         }
 
-        const [isValid, err] = await validatePerfResultsFolder(folderPath);
+        const [isValid, err] = validatePerfResultsFolder(folderPath);
         if (!isValid) {
             // eslint-disable-next-line no-alert
             alert(`Invalid folder selected: ${err}`);

--- a/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
+++ b/src/renderer/hooks/usePerfAnalyzerFileLoader.hooks.ts
@@ -11,13 +11,13 @@ import {
     setSelectedFolderLocationType,
 } from 'data/store/slices/uiState.slice';
 import { useDispatch, useSelector } from 'react-redux';
-import { getAvailableGraphNames, loadCluster, loadGraph, validatePerfResultsFolder } from 'utils/FileLoaders';
+import { getAvailableGraphRelationships, loadCluster, loadGraph, validatePerfResultsFolder } from 'utils/FileLoaders';
 
 import { dialog } from '@electron/remote';
 import { ApplicationMode } from 'data/Types';
 import { useContext, useEffect, useState } from 'react';
 import { type Location, useLocation, useNavigate } from 'react-router-dom';
-import { sortPerfAnalyzerGraphnames } from 'utils/FilenameSorters';
+import { sortPerfAnalyzerGraphRelationships } from 'utils/FilenameSorters';
 import { ClusterContext, ClusterModel } from '../../data/ClusterContext';
 import type GraphOnChip from '../../data/GraphOnChip';
 import type { NodeInitialState } from '../../data/GraphOnChip';
@@ -85,14 +85,14 @@ const usePerfAnalyzerFileLoader = () => {
         try {
             // TODO: needs gone once we are happy with performance
             const entireRunStartTime = performance.now();
-            graphs = await getAvailableGraphNames(folderPath);
+            graphs = await getAvailableGraphRelationships(folderPath);
 
             if (!graphs.length) {
                 throw new Error(`No graphs found in\n${folderPath}`);
             }
 
             dispatch(setSelectedFolder(folderPath));
-            const sortedGraphs = sortPerfAnalyzerGraphnames(graphs);
+            const sortedGraphs = sortPerfAnalyzerGraphRelationships(graphs);
             const graphOnChipList: GraphOnChip[] = [];
             const linkDataByTemporalEpoch: NetworkCongestionState['linksPerTemporalEpoch'] = [];
             const pipeSelectionData: PipeSelection[] = [];

--- a/src/renderer/hooks/useSelectableGraphVertex.hook.ts
+++ b/src/renderer/hooks/useSelectableGraphVertex.hook.ts
@@ -25,7 +25,10 @@ const useSelectableGraphVertex = () => {
             return () => {
                 const operand = getOperand(operandName);
                 if (operand) {
-                    loadPerfAnalyzerGraph(operand.graphName);
+                    loadPerfAnalyzerGraph({
+                        chipId: operand.chipId,
+                        temporalEpoch: operand.temporalEpoch,
+                    });
                 }
             };
         },

--- a/src/utils/FileLoaders.ts
+++ b/src/utils/FileLoaders.ts
@@ -224,7 +224,6 @@ const isFileMatchByIdOrEpoch = (filename: string, id: number | null, epoch: numb
 
 const loadChipFromNetlistAnalyzer = async (
     folderPath: string,
-    graphName: string,
     chipId: number | null,
     temporalEpoch: number | null,
 ): Promise<GraphOnChip | null> => {
@@ -284,7 +283,6 @@ export const loadGraph = async (folderPath: string, graph: GraphRelationship): P
 
     let graphOnChip: GraphOnChip | null = await loadChipFromNetlistAnalyzer(
         path.join(folderPath),
-        name,
         chipId,
         temporalEpoch,
     );

--- a/src/utils/FileLoaders.ts
+++ b/src/utils/FileLoaders.ts
@@ -98,13 +98,14 @@ export const findFiles = async (
  * this used to check for all of the important folders. we no longer care
  * the app can work as long as there is at least something usable there.
  */
-export const validatePerfResultsFolder = async (dirPath: string): Promise<[isValid: boolean, error: string | null]> => {
+export const validatePerfResultsFolder = (dirPath: string): [boolean, string | null] => {
     if (!fs.existsSync(dirPath)) {
         return [false, 'Folder does not exist'];
     }
     return [true, null];
 };
-const getAvailableGraphNamesFromNetlistAnalyzer = async (folderPath: string): Promise<GraphRelationship[]> => {
+
+const getAvailableGraphRelationshipsFromNetlistAnalyzer = async (folderPath: string) => {
     try {
         const netlistAnalyzerFiles = await readDirEntries(path.join(folderPath, 'netlist_analyzer'));
         return netlistAnalyzerFiles
@@ -126,7 +127,7 @@ const getAvailableGraphNamesFromNetlistAnalyzer = async (folderPath: string): Pr
     }
 };
 
-export const getAvailableGraphNames = async (perfResultsPath: string): Promise<GraphRelationship[]> => {
+export const getAvailableGraphRelationships = async (perfResultsPath: string) => {
     try {
         const runtimeDataPath = path.join(perfResultsPath, 'runtime_data.yaml');
         const runtimeDataYaml = await readFile(runtimeDataPath);
@@ -146,7 +147,7 @@ export const getAvailableGraphNames = async (perfResultsPath: string): Promise<G
         console.error('Failed to read runtime_data.yaml', err);
     }
 
-    return getAvailableGraphNamesFromNetlistAnalyzer(perfResultsPath);
+    return getAvailableGraphRelationshipsFromNetlistAnalyzer(perfResultsPath);
 };
 
 export const loadCluster = async (perfResultsPath: string): Promise<Cluster | null> => {

--- a/src/utils/FilenameSorters.ts
+++ b/src/utils/FilenameSorters.ts
@@ -21,19 +21,20 @@ export function sortNetlistAnalyzerFiles(filenames: GraphRelationship[]) {
     });
 }
 
-export function sortPerfAnalyzerGraphnames(filenames: GraphRelationship[]) {
-    return filenames.sort((a, b) => {
-        const parsedA = PERF_ANALYZER_REGEX.exec(a.name);
-        const parsedB = PERF_ANALYZER_REGEX.exec(b.name);
-        if (!parsedA?.[1] || !parsedB?.[1]) {
-            return 1;
-        }
-        if (Number(parsedA[1]) === Number(parsedB[1])) {
-            if (Number(parsedA[2]) === Number(parsedB[2])) {
-                return Number(parsedA[3]) > Number(parsedB[3]) ? 1 : -1;
-            }
-            return Number(parsedA[2]) > Number(parsedB[2]) ? 1 : -1;
-        }
-        return Number(parsedA[1]) > Number(parsedB[1]) ? 1 : -1;
+export function sortPerfAnalyzerGraphRelationships(graphRelationships: GraphRelationship[]) {
+    const sortedRelationships = graphRelationships.sort((a, b) => {
+        const temporalEpochDelta = a.temporalEpoch - b.temporalEpoch;
+        const chipIdDelta = a.chipId - b.chipId;
+
+        const [, aFirstDigit, aSecondDigit, aThirdDigit] = PERF_ANALYZER_REGEX.exec(a.name) ?? [];
+        const [, bFirstDigit, bSecondDigit, bThirdDigit] = PERF_ANALYZER_REGEX.exec(b.name) ?? [];
+
+        const firstDigitDelta = Number.parseInt(aFirstDigit, 10) - Number.parseInt(bFirstDigit, 10);
+        const secondDigitDelta = Number.parseInt(aSecondDigit, 10) - Number.parseInt(bSecondDigit, 10);
+        const thirdDigitDelta = Number.parseInt(aThirdDigit, 10) - Number.parseInt(bThirdDigit, 10);
+
+        return temporalEpochDelta || chipIdDelta || firstDigitDelta || secondDigitDelta || thirdDigitDelta;
     });
+
+    return sortedRelationships;
 }

--- a/src/utils/__tests__/test_files.ts
+++ b/src/utils/__tests__/test_files.ts
@@ -5,7 +5,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { findFiles, getAvailableGraphNames, readDirEntries, validatePerfResultsFolder } from '../FileLoaders';
+import { findFiles, getAvailableGraphRelationships, readDirEntries, validatePerfResultsFolder } from '../FileLoaders';
 
 const generateRandomKey = () => Math.random().toString(36).substring(2);
 
@@ -158,7 +158,7 @@ describe('Folder utilities:', () => {
             fs.rmSync(perfResultsPath, { recursive: true });
         });
         it('Should list available graphs from a perf_results folder', () => {
-            const actualGraphNames = getAvailableGraphNames(perfResultsPath);
+            const actualGraphNames = getAvailableGraphRelationships(perfResultsPath);
             return expect(actualGraphNames).resolves.toEqual(graphNames);
         });
     });


### PR DESCRIPTION
We had graphs being saved and retrieved differently depending on the method called.

One of them used the graph name, one used an indexed array with the chip id as the index, one others used maps, and yet another used indexed arrays but out sorted by graph name.

This PR fixes that by changing the reference to always point to the same data structure so we consistently reference graphs by temporal epoch + chip id now.